### PR TITLE
Full conversion to real trait...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ name = "aether"
 version = "0.1.1"
 dependencies = [
  "aether_benchmark",
- "aether_core 0.1.1",
+ "aether_core",
  "aether_examples",
  "aether_fluids",
  "aether_graphics",
@@ -46,18 +46,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aether_core"
-version = "0.1.1"
-source = "git+https://github.com/AtmoPierce/aether.git#8b4ad4a464a79957baf10dea26a364473be802aa"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "aether_examples"
 version = "0.1.1"
 dependencies = [
- "aether_core 0.1.1",
+ "aether_core",
 ]
 
 [[package]]
@@ -68,7 +60,7 @@ version = "0.1.1"
 name = "aether_graphics"
 version = "0.1.1"
 dependencies = [
- "aether_core 0.1.1",
+ "aether_core",
  "num-traits",
 ]
 
@@ -76,7 +68,7 @@ dependencies = [
 name = "aether_ml"
 version = "0.1.1"
 dependencies = [
- "aether_core 0.1.1",
+ "aether_core",
  "aether_opt",
  "csv",
  "minstant",
@@ -89,14 +81,14 @@ dependencies = [
 name = "aether_models"
 version = "0.1.1"
 dependencies = [
- "aether_core 0.1.1",
+ "aether_core",
 ]
 
 [[package]]
 name = "aether_opt"
 version = "0.1.1"
 dependencies = [
- "aether_core 0.1.1",
+ "aether_core",
  "aether_rand",
  "num-traits",
 ]
@@ -109,7 +101,7 @@ version = "0.1.1"
 name = "aether_shapes"
 version = "0.1.1"
 dependencies = [
- "aether_core 0.1.1",
+ "aether_core",
  "num-traits",
 ]
 
@@ -117,7 +109,7 @@ dependencies = [
 name = "aether_stats"
 version = "0.1.1"
 dependencies = [
- "aether_core 0.1.1",
+ "aether_core",
  "aether_opt",
  "aether_rand",
  "num-traits",
@@ -127,7 +119,7 @@ dependencies = [
 name = "aether_test"
 version = "0.1.1"
 dependencies = [
- "aether_core 0.1.1",
+ "aether_core",
  "aether_viz",
  "approx",
  "num-traits",
@@ -138,8 +130,7 @@ dependencies = [
 name = "aether_units"
 version = "0.1.1"
 dependencies = [
- "aether_core 0.1.1",
- "fpx",
+ "aether_core",
 ]
 
 [[package]]
@@ -505,15 +496,6 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
-name = "fpx"
-version = "0.1.0"
-source = "git+https://github.com/AtmoPierce/fpx.git#6d39e01a253eed197152a05a32edf2df36f34a71"
-dependencies = [
- "aether_core 0.1.1 (git+https://github.com/AtmoPierce/aether.git)",
- "num-traits",
-]
 
 [[package]]
 name = "freetype-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,3 @@ panic = "abort"
 [profile.dev.package."*"]
 # Optimize all dependencies even in debug builds
 opt-level = 2
-
-[workspace.dependencies]
-num_traits = {version = "*"}

--- a/crates/aether_core/src/attitude/dcm.rs
+++ b/crates/aether_core/src/attitude/dcm.rs
@@ -3,16 +3,15 @@ use super::quaternion::Quaternion;
 use crate::{coordinate::Cartesian, math::Matrix, reference_frame::ReferenceFrame};
 use core::marker::PhantomData;
 use core::ops::{Add, Div, Mul, Neg, Sub};
-use num_traits::Float;
-
+use crate::real::Real;
 #[derive(Debug, Clone, Copy, Default)]
-pub struct DirectionCosineMatrix<T: Float, From: ReferenceFrame, To: ReferenceFrame> {
+pub struct DirectionCosineMatrix<T: Real, From: ReferenceFrame, To: ReferenceFrame> {
     data: Matrix<T, 3, 3>, // still private
     _from: PhantomData<From>,
     _to: PhantomData<To>,
 }
 
-impl<T: Float, From: ReferenceFrame, To: ReferenceFrame> DirectionCosineMatrix<T, From, To> {
+impl<T: Real, From: ReferenceFrame, To: ReferenceFrame> DirectionCosineMatrix<T, From, To> {
     pub fn new(m11: T, m12: T, m13: T, m21: T, m22: T, m23: T, m31: T, m32: T, m33: T) -> Self {
         let data = Matrix {
             data: [[m11, m12, m13], [m21, m22, m23], [m31, m32, m33]],
@@ -40,9 +39,9 @@ impl<T: Float, From: ReferenceFrame, To: ReferenceFrame> DirectionCosineMatrix<T
     pub fn rotate_x(angle: T) -> Self {
         let (c, s) = (angle.cos(), angle.sin());
         let data: [[T; 3]; 3] = [
-            [T::one(), T::zero(), T::zero()],
-            [T::zero(), c, s],
-            [T::zero(), -s, c],
+            [T::ONE, T::ZERO, T::ZERO],
+            [T::ZERO, c, s],
+            [T::ZERO, -s, c],
         ];
         Self {
             data: Matrix { data },
@@ -54,9 +53,9 @@ impl<T: Float, From: ReferenceFrame, To: ReferenceFrame> DirectionCosineMatrix<T
     pub fn rotate_y(angle: T) -> Self {
         let (c, s) = (angle.cos(), angle.sin());
         let data = [
-            [c, T::zero(), -s],
-            [T::zero(), T::one(), T::zero()],
-            [s, T::zero(), c],
+            [c, T::ZERO, -s],
+            [T::ZERO, T::ONE, T::ZERO],
+            [s, T::ZERO, c],
         ];
         Self {
             data: Matrix { data },
@@ -69,9 +68,9 @@ impl<T: Float, From: ReferenceFrame, To: ReferenceFrame> DirectionCosineMatrix<T
         let (c, s) = (angle.cos(), angle.sin());
 
         let data = [
-            [c, s, T::zero()],
-            [-s, c, T::zero()],
-            [T::zero(), T::zero(), T::one()],
+            [c, s, T::ZERO],
+            [-s, c, T::ZERO],
+            [T::ZERO, T::ZERO, T::ONE],
         ];
         Self {
             data: Matrix { data },
@@ -83,7 +82,7 @@ impl<T: Float, From: ReferenceFrame, To: ReferenceFrame> DirectionCosineMatrix<T
 
 impl<T, A, B, C> Mul<DirectionCosineMatrix<T, A, B>> for DirectionCosineMatrix<T, B, C>
 where
-    T: Float,
+    T: Real,
     A: ReferenceFrame,
     B: ReferenceFrame,
     C: ReferenceFrame,
@@ -101,7 +100,7 @@ where
 // From
 impl<T, A: ReferenceFrame, B: ReferenceFrame> From<Euler<T>> for DirectionCosineMatrix<T, A, B>
 where
-    T: Float + Mul<Output = T> + Add<Output = T> + Copy + Default,
+    T: Real + Mul<Output = T> + Add<Output = T> + Copy + Default,
 {
     fn from(euler: Euler<T>) -> Self {
         // ZYX Convention
@@ -115,7 +114,7 @@ where
     }
 }
 
-impl<T: Float, A: ReferenceFrame, B: ReferenceFrame> From<Quaternion<T>>
+impl<T: Real, A: ReferenceFrame, B: ReferenceFrame> From<Quaternion<T>>
     for DirectionCosineMatrix<T, A, B>
 {
     fn from(q: Quaternion<T>) -> Self {
@@ -124,7 +123,7 @@ impl<T: Float, A: ReferenceFrame, B: ReferenceFrame> From<Quaternion<T>>
         let j = q.data.data[2];
         let k = q.data.data[3];
 
-        let two = T::one() + T::one();
+        let two = T::ONE + T::ONE;
         let sp2 = s.powf(two);
         let ip2 = i.powf(two);
         let jp2 = j.powf(two);
@@ -155,7 +154,7 @@ impl<T: Float, A: ReferenceFrame, B: ReferenceFrame> From<Quaternion<T>>
     }
 }
 
-impl<T: Float, A: ReferenceFrame, B: ReferenceFrame> From<&Matrix<T, 3, 3>>
+impl<T: Real, A: ReferenceFrame, B: ReferenceFrame> From<&Matrix<T, 3, 3>>
     for DirectionCosineMatrix<T, A, B>
 {
     fn from(m: &Matrix<T, 3, 3>) -> Self {
@@ -168,7 +167,7 @@ impl<T: Float, A: ReferenceFrame, B: ReferenceFrame> From<&Matrix<T, 3, 3>>
 }
 
 // Cartesian Handling
-impl<T: Float, From: ReferenceFrame, To: ReferenceFrame> Mul<Cartesian<T, From>>
+impl<T: Real, From: ReferenceFrame, To: ReferenceFrame> Mul<Cartesian<T, From>>
     for DirectionCosineMatrix<T, From, To>
 {
     type Output = Cartesian<T, To>;
@@ -182,7 +181,7 @@ impl<T: Float, From: ReferenceFrame, To: ReferenceFrame> Mul<Cartesian<T, From>>
 }
 
 // Behavior
-impl<T: Float + Copy, From: ReferenceFrame, To: ReferenceFrame> DirectionCosineMatrix<T, From, To> {
+impl<T: Real + Copy, From: ReferenceFrame, To: ReferenceFrame> DirectionCosineMatrix<T, From, To> {
     pub fn m11(&self) -> T {
         self.data[(0, 0)]
     }
@@ -226,7 +225,7 @@ impl<T: Float + Copy, From: ReferenceFrame, To: ReferenceFrame> DirectionCosineM
 }
 
 #[cfg(feature = "std")]
-impl<T: Float + std::fmt::Display, A: ReferenceFrame, B: ReferenceFrame> std::fmt::Display
+impl<T: Real + std::fmt::Display, A: ReferenceFrame, B: ReferenceFrame> std::fmt::Display
     for DirectionCosineMatrix<T, A, B>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/aether_core/src/attitude/determination.rs
+++ b/crates/aether_core/src/attitude/determination.rs
@@ -1,14 +1,13 @@
 use crate::coordinate::Cartesian;
 use crate::reference_frame::{Body, ICRF};
-use num_traits::{Float, FromPrimitive};
-
-pub struct QuestObservation<T: Float, Body, ICRF> {
+use crate::real::Real;
+pub struct QuestObservation<T: Real, Body, ICRF> {
     pub body: Cartesian<T, Body>,
     pub inertial: Cartesian<T, ICRF>,
     pub weight: T,
 }
 
-// pub fn quest<Body, ICRF, T: Float>(observation: &[QuestObservation<T, Body, ICRF>]) -> Option<Cartesian<T, Body>> where T: Float + FromPrimitive {
+// pub fn quest<Body, ICRF, T: Real>(observation: &[QuestObservation<T, Body, ICRF>]) -> Option<Cartesian<T, Body>> where T: Real + FromPrimitive {
 //     if observation.len() < 2 {
 //         return None;
 //     }

--- a/crates/aether_core/src/attitude/euler.rs
+++ b/crates/aether_core/src/attitude/euler.rs
@@ -3,14 +3,13 @@ use crate::math::Vector;
 use crate::reference_frame::ReferenceFrame;
 use crate::utils::angle_conversion::{ToDegrees, ToRadians};
 use core::ops::{Add, Div, Mul, Neg, Sub};
-use num_traits::Float;
-
+use crate::real::Real;
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
-pub struct Euler<T: Float> {
+pub struct Euler<T: Real> {
     pub data: Vector<T, 3>, // [roll, pitch, yaw]
 }
 
-impl<T: Float> Euler<T> {
+impl<T: Real> Euler<T> {
     pub fn new(roll: T, pitch: T, yaw: T) -> Self {
         Self {
             data: Vector {
@@ -30,21 +29,21 @@ impl<T: Float> Euler<T> {
     }
 }
 
-impl<T: Float> From<&Quaternion<T>> for Euler<T> {
+impl<T: Real> From<&Quaternion<T>> for Euler<T> {
     fn from(q: &Quaternion<T>) -> Self {
         let w = q.data.data[0];
         let x = q.data.data[1];
         let y = q.data.data[2];
         let z = q.data.data[3];
-        let two = T::one() + T::one();
-        let one = T::one();
+        let two = T::ONE + T::ONE;
+        let one = T::ONE;
 
         let sinr_cosp = two * (w * x + y * z);
         let cosr_cosp = one - two * (x * x + y * y);
         let roll = sinr_cosp.atan2(cosr_cosp);
 
         let sinp = two * (w * y - z * x);
-        let half_pi = T::from(core::f64::consts::FRAC_PI_2).unwrap();
+        let half_pi = T::FRAC_PI_2;
         let pitch = if sinp.abs() >= one {
             half_pi * sinp.signum()
         } else {
@@ -59,7 +58,7 @@ impl<T: Float> From<&Quaternion<T>> for Euler<T> {
     }
 }
 
-impl<T: Float, A: ReferenceFrame, B: ReferenceFrame> From<&DirectionCosineMatrix<T, A, B>>
+impl<T: Real, A: ReferenceFrame, B: ReferenceFrame> From<&DirectionCosineMatrix<T, A, B>>
     for Euler<T>
 {
     fn from(dcm: &DirectionCosineMatrix<T, A, B>) -> Self {
@@ -72,7 +71,7 @@ impl<T: Float, A: ReferenceFrame, B: ReferenceFrame> From<&DirectionCosineMatrix
 }
 
 // Add
-impl<T: Float> Add for Euler<T> {
+impl<T: Real> Add for Euler<T> {
     type Output = Self;
     fn add(self, rhs: Self) -> Self {
         Self {
@@ -82,7 +81,7 @@ impl<T: Float> Add for Euler<T> {
 }
 
 // Sub
-impl<T: Float> Sub for Euler<T> {
+impl<T: Real> Sub for Euler<T> {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self {
         Self {
@@ -92,7 +91,7 @@ impl<T: Float> Sub for Euler<T> {
 }
 
 // Neg
-impl<T: Float> Neg for Euler<T> {
+impl<T: Real> Neg for Euler<T> {
     type Output = Self;
     fn neg(self) -> Self {
         Self { data: -self.data }
@@ -100,7 +99,7 @@ impl<T: Float> Neg for Euler<T> {
 }
 
 // Scalar multiplication
-impl<T: Float> Mul<T> for Euler<T> {
+impl<T: Real> Mul<T> for Euler<T> {
     type Output = Self;
     fn mul(self, rhs: T) -> Self {
         Self {
@@ -110,7 +109,7 @@ impl<T: Float> Mul<T> for Euler<T> {
 }
 
 // Scalar division
-impl<T: Float> Div<T> for Euler<T> {
+impl<T: Real> Div<T> for Euler<T> {
     type Output = Self;
     fn div(self, rhs: T) -> Self {
         Self {
@@ -122,7 +121,7 @@ impl<T: Float> Div<T> for Euler<T> {
 // Unit Conversions
 impl<T> Euler<T>
 where
-    T: Float + ToRadians<Output = T> + ToDegrees<Output = T> + Copy,
+    T: Real + ToRadians<Output = T> + ToDegrees<Output = T> + Copy,
 {
     /// Create Euler angles from degrees vector.
     pub fn from_degrees_vec(deg: Vector<T, 3>) -> Self {
@@ -142,7 +141,7 @@ where
 use std::fmt;
 
 #[cfg(feature = "std")]
-impl<T: Float + fmt::Display> fmt::Display for Euler<T> {
+impl<T: Real + fmt::Display> fmt::Display for Euler<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.data)
     }

--- a/crates/aether_core/src/attitude/mod.rs
+++ b/crates/aether_core/src/attitude/mod.rs
@@ -13,14 +13,13 @@ pub mod tests;
 
 pub mod attitude {
     use crate::reference_frame::ReferenceFrame;
-    use num_traits::Float;
-
+    use crate::real::Real;
     use super::dcm::DirectionCosineMatrix;
     use super::euler::Euler;
     use super::quaternion::Quaternion;
     pub enum Rotation<T, From: ReferenceFrame, To: ReferenceFrame>
     where
-        T: Float,
+        T: Real,
     {
         DCMRotation(DirectionCosineMatrix<T, From, To>),
         EulerRotation(Euler<T>),

--- a/crates/aether_core/src/attitude/tests/dcm_tests.rs
+++ b/crates/aether_core/src/attitude/tests/dcm_tests.rs
@@ -6,8 +6,7 @@ mod tests {
     use crate::math::Matrix;
     use crate::matrix;
     use approx::assert_relative_eq;
-    use num_traits::Float;
-
+    use crate::real::Real;
     const EPSILON: f64 = 1e-6;
 
     #[test]

--- a/crates/aether_core/src/attitude/tests/euler_tests.rs
+++ b/crates/aether_core/src/attitude/tests/euler_tests.rs
@@ -5,8 +5,7 @@ mod tests {
     use crate::matrix;
     use crate::reference_frame::Body;
     use approx::assert_relative_eq;
-    use num_traits::Float;
-
+    use crate::real::Real;
     #[test]
     fn test_euler_dcm_roundtrip() {
         let euler = Euler::new(-0.5, 0.1, 0.2);

--- a/crates/aether_core/src/attitude/tests/quaternion_tests.rs
+++ b/crates/aether_core/src/attitude/tests/quaternion_tests.rs
@@ -1,8 +1,7 @@
 mod tests {
     use crate::attitude::{DirectionCosineMatrix, Euler, Quaternion};
     use crate::reference_frame::Body;
-    use num_traits::Float;
-
+    use crate::real::Real;
     const EPSILON: f64 = 1e-6;
 
     #[test]

--- a/crates/aether_core/src/attitude/tests/test_utils.rs
+++ b/crates/aether_core/src/attitude/tests/test_utils.rs
@@ -3,9 +3,8 @@ use crate::attitude::{DirectionCosineMatrix, Euler, Quaternion};
 use crate::reference_frame::Body;
 use crate::{math::Matrix, matrix};
 use approx::assert_relative_eq;
-use num_traits::Float;
-
-pub fn matrices_approx_eq<T: Float + std::fmt::Debug>(
+use crate::real::Real;
+pub fn matrices_approx_eq<T: Real + std::fmt::Debug>(
     a: &Matrix<T, 3, 3>,
     b: &Matrix<T, 3, 3>,
     epsilon: T,
@@ -28,7 +27,7 @@ pub fn matrices_approx_eq<T: Float + std::fmt::Debug>(
 
 pub fn test_round_trip<T>(dcm: DirectionCosineMatrix<T, Body<f64>, Body<f64>>, epsilon: T)
 where
-    T: Float + std::fmt::Debug,
+    T: Real + std::fmt::Debug,
 {
     let q: Quaternion<T> = (&dcm).try_into().unwrap();
     let q_n = q.normalized();

--- a/crates/aether_core/src/coordinate/cartesian.rs
+++ b/crates/aether_core/src/coordinate/cartesian.rs
@@ -6,15 +6,15 @@ use crate::reference_frame::ReferenceFrame;
 
 use core::marker::PhantomData; // Reference frame tracking.
 use core::slice::{Iter, IterMut};
-use num_traits::Float;
+use crate::real::Real;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct Cartesian<T: Float, ReferenceFrame> {
+pub struct Cartesian<T: Real, ReferenceFrame> {
     pub data: Vector<T, 3>,
     pub _reference_frame: PhantomData<ReferenceFrame>,
 }
 
-impl<T: Float, RF: ReferenceFrame> Cartesian<T, RF> {
+impl<T: Real, RF: ReferenceFrame> Cartesian<T, RF> {
     pub fn new(x: T, y: T, z: T) -> Self {
         Self {
             data: Vector { data: [x, y, z] },
@@ -39,7 +39,7 @@ impl<T: Float, RF: ReferenceFrame> Cartesian<T, RF> {
     }
 }
 
-impl<T: Float, RF: ReferenceFrame> Cartesian<T, RF> {
+impl<T: Real, RF: ReferenceFrame> Cartesian<T, RF> {
     pub fn cross(&self, rhs: &Self) -> Self {
         Self {
             data: self.data.cross(&rhs.data),
@@ -63,11 +63,11 @@ impl<T: Float, RF: ReferenceFrame> Cartesian<T, RF> {
     }
 }
 // Behavior
-impl<T: Float, RF> Cartesian<T, RF> {
+impl<T: Real, RF> Cartesian<T, RF> {
     pub fn zero() -> Self {
         Self {
             data: Vector {
-                data: [T::zero(); 3],
+                data: [T::ZERO; 3],
             },
             _reference_frame: PhantomData,
         }
@@ -76,7 +76,7 @@ impl<T: Float, RF> Cartesian<T, RF> {
 
 use core::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 // ----- Add -----
-impl<T: Float, RF> Add for Cartesian<T, RF> {
+impl<T: Real, RF> Add for Cartesian<T, RF> {
     type Output = Self;
     fn add(self, rhs: Self) -> Self::Output {
         Self {
@@ -85,7 +85,7 @@ impl<T: Float, RF> Add for Cartesian<T, RF> {
         }
     }
 }
-impl<'a, T: Float, RF> Add for &'a Cartesian<T, RF> {
+impl<'a, T: Real, RF> Add for &'a Cartesian<T, RF> {
     type Output = Cartesian<T, RF>;
     fn add(self, rhs: Self) -> Self::Output {
         Cartesian {
@@ -95,7 +95,7 @@ impl<'a, T: Float, RF> Add for &'a Cartesian<T, RF> {
     }
 }
 
-impl<'a, T: Float, RF> Add<Cartesian<T, RF>> for &'a Cartesian<T, RF> {
+impl<'a, T: Real, RF> Add<Cartesian<T, RF>> for &'a Cartesian<T, RF> {
     type Output = Cartesian<T, RF>;
     fn add(self, rhs: Cartesian<T, RF>) -> Self::Output {
         Cartesian {
@@ -104,7 +104,7 @@ impl<'a, T: Float, RF> Add<Cartesian<T, RF>> for &'a Cartesian<T, RF> {
         }
     }
 }
-impl<'a, T: Float, RF> Add<&'a Cartesian<T, RF>> for Cartesian<T, RF> {
+impl<'a, T: Real, RF> Add<&'a Cartesian<T, RF>> for Cartesian<T, RF> {
     type Output = Cartesian<T, RF>;
     fn add(self, rhs: &'a Cartesian<T, RF>) -> Self::Output {
         Cartesian {
@@ -115,14 +115,14 @@ impl<'a, T: Float, RF> Add<&'a Cartesian<T, RF>> for Cartesian<T, RF> {
 }
 
 // ----- AddAssign -----
-impl<T: Float + AddAssign, RF> AddAssign for Cartesian<T, RF> {
+impl<T: Real + AddAssign, RF> AddAssign for Cartesian<T, RF> {
     fn add_assign(&mut self, rhs: Self) {
         self.data += rhs.data;
     }
 }
 
 // ----- Sub -----
-impl<T: Float, RF> Sub for Cartesian<T, RF> {
+impl<T: Real, RF> Sub for Cartesian<T, RF> {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self::Output {
         Self {
@@ -131,7 +131,7 @@ impl<T: Float, RF> Sub for Cartesian<T, RF> {
         }
     }
 }
-impl<'a, T: Float, RF> Sub for &'a Cartesian<T, RF> {
+impl<'a, T: Real, RF> Sub for &'a Cartesian<T, RF> {
     type Output = Cartesian<T, RF>;
     fn sub(self, rhs: Self) -> Self::Output {
         Cartesian {
@@ -140,7 +140,7 @@ impl<'a, T: Float, RF> Sub for &'a Cartesian<T, RF> {
         }
     }
 }
-impl<'a, T: Float, RF> Sub<Cartesian<T, RF>> for &'a Cartesian<T, RF> {
+impl<'a, T: Real, RF> Sub<Cartesian<T, RF>> for &'a Cartesian<T, RF> {
     type Output = Cartesian<T, RF>;
     fn sub(self, rhs: Cartesian<T, RF>) -> Self::Output {
         Cartesian {
@@ -149,7 +149,7 @@ impl<'a, T: Float, RF> Sub<Cartesian<T, RF>> for &'a Cartesian<T, RF> {
         }
     }
 }
-impl<'a, T: Float, RF> Sub<&'a Cartesian<T, RF>> for Cartesian<T, RF>
+impl<'a, T: Real, RF> Sub<&'a Cartesian<T, RF>> for Cartesian<T, RF>
 where
     Cartesian<T, RF>: Clone,
 {
@@ -163,14 +163,14 @@ where
 }
 
 // ----- SubAssign -----
-impl<T: Float + SubAssign, RF> SubAssign for Cartesian<T, RF> {
+impl<T: Real + SubAssign, RF> SubAssign for Cartesian<T, RF> {
     fn sub_assign(&mut self, rhs: Self) {
         self.data -= rhs.data;
     }
 }
 
 // ----- Neg -----
-impl<T: Float, RF> Neg for Cartesian<T, RF> {
+impl<T: Real, RF> Neg for Cartesian<T, RF> {
     type Output = Self;
     fn neg(self) -> Self::Output {
         Cartesian {
@@ -179,7 +179,7 @@ impl<T: Float, RF> Neg for Cartesian<T, RF> {
         }
     }
 }
-impl<'a, T: Float, RF> Neg for &'a Cartesian<T, RF>
+impl<'a, T: Real, RF> Neg for &'a Cartesian<T, RF>
 where
     Cartesian<T, RF>: Clone,
 {
@@ -193,7 +193,7 @@ where
 }
 
 // ----- Scalar Mul -----
-impl<T: Float + Copy, RF> Mul<T> for Cartesian<T, RF> {
+impl<T: Real + Copy, RF> Mul<T> for Cartesian<T, RF> {
     type Output = Self;
     fn mul(self, rhs: T) -> Self {
         Self {
@@ -202,7 +202,7 @@ impl<T: Float + Copy, RF> Mul<T> for Cartesian<T, RF> {
         }
     }
 }
-impl<'a, T: Float + Copy, RF> Mul<T> for &'a Cartesian<T, RF> {
+impl<'a, T: Real + Copy, RF> Mul<T> for &'a Cartesian<T, RF> {
     type Output = Cartesian<T, RF>;
     fn mul(self, rhs: T) -> Self::Output {
         Cartesian {
@@ -213,7 +213,7 @@ impl<'a, T: Float + Copy, RF> Mul<T> for &'a Cartesian<T, RF> {
 }
 
 // ----- Scalar Div -----
-impl<T: Float + Copy, RF> Div<T> for Cartesian<T, RF> {
+impl<T: Real + Copy, RF> Div<T> for Cartesian<T, RF> {
     type Output = Self;
     fn div(self, rhs: T) -> Self::Output {
         Cartesian {
@@ -225,7 +225,7 @@ impl<T: Float + Copy, RF> Div<T> for Cartesian<T, RF> {
 // Indexing
 use core::ops::{Index, IndexMut};
 
-impl<T: Float, ReferenceFrame> Index<usize> for Cartesian<T, ReferenceFrame> {
+impl<T: Real, ReferenceFrame> Index<usize> for Cartesian<T, ReferenceFrame> {
     type Output = T;
 
     fn index(&self, index: usize) -> &Self::Output {
@@ -233,13 +233,13 @@ impl<T: Float, ReferenceFrame> Index<usize> for Cartesian<T, ReferenceFrame> {
     }
 }
 
-impl<T: Float, ReferenceFrame> IndexMut<usize> for Cartesian<T, ReferenceFrame> {
+impl<T: Real, ReferenceFrame> IndexMut<usize> for Cartesian<T, ReferenceFrame> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.data.data[index]
     }
 }
 
-impl<'a, T: Float + Copy, RF> Div<T> for &'a Cartesian<T, RF>
+impl<'a, T: Real + Copy, RF> Div<T> for &'a Cartesian<T, RF>
 where
     Cartesian<T, RF>: Clone,
 {
@@ -252,7 +252,7 @@ where
     }
 }
 
-impl<T: Float + Copy + Default, F> Mul<Cartesian<T, F>> for Matrix<T, 3, 3> {
+impl<T: Real + Copy + Default, F> Mul<Cartesian<T, F>> for Matrix<T, 3, 3> {
     type Output = Cartesian<T, F>;
     fn mul(self, rhs: Cartesian<T, F>) -> Self::Output {
         let v = self * rhs.data; // Use existing `Matrix * Vector` implementation
@@ -264,7 +264,7 @@ impl<T: Float + Copy + Default, F> Mul<Cartesian<T, F>> for Matrix<T, 3, 3> {
 }
 
 // Conversions
-impl<T: Float, RF: ReferenceFrame> From<&Spherical<T>> for Cartesian<T, RF> {
+impl<T: Real, RF: ReferenceFrame> From<&Spherical<T>> for Cartesian<T, RF> {
     fn from(p: &Spherical<T>) -> Self {
         let r = p.r();
         let phi = p.phi(); // azimuth
@@ -277,7 +277,7 @@ impl<T: Float, RF: ReferenceFrame> From<&Spherical<T>> for Cartesian<T, RF> {
     }
 }
 
-impl<T: Float, RF: ReferenceFrame> From<&Cylindrical<T>> for Cartesian<T, RF> {
+impl<T: Real, RF: ReferenceFrame> From<&Cylindrical<T>> for Cartesian<T, RF> {
     fn from(c: &Cylindrical<T>) -> Self {
         let x = c.r() * c.theta().cos();
         let y = c.r() * c.theta().sin();
@@ -288,13 +288,13 @@ impl<T: Float, RF: ReferenceFrame> From<&Cylindrical<T>> for Cartesian<T, RF> {
 
 // Iterator
 // --- AsRef / AsMut ---
-impl<T: num_traits::Float, RF> AsRef<[T; 3]> for Cartesian<T, RF> {
+impl<T: Real, RF> AsRef<[T; 3]> for Cartesian<T, RF> {
     #[inline]
     fn as_ref(&self) -> &[T; 3] {
         &self.data.data
     }
 }
-impl<T: num_traits::Float, RF> AsMut<[T; 3]> for Cartesian<T, RF> {
+impl<T: Real, RF> AsMut<[T; 3]> for Cartesian<T, RF> {
     #[inline]
     fn as_mut(&mut self) -> &mut [T; 3] {
         &mut self.data.data
@@ -302,7 +302,7 @@ impl<T: num_traits::Float, RF> AsMut<[T; 3]> for Cartesian<T, RF> {
 }
 
 // --- Convenience methods ---
-impl<T: num_traits::Float, RF> Cartesian<T, RF> {
+impl<T: Real, RF> Cartesian<T, RF> {
     #[inline]
     pub fn iter(&self) -> Iter<'_, T> {
         self.data.iter()
@@ -314,7 +314,7 @@ impl<T: num_traits::Float, RF> Cartesian<T, RF> {
 }
 
 // --- IntoIterator (by value) ---
-impl<T: num_traits::Float, RF> IntoIterator for Cartesian<T, RF> {
+impl<T: Real, RF> IntoIterator for Cartesian<T, RF> {
     type Item = T;
     type IntoIter = <Vector<T, 3> as IntoIterator>::IntoIter;
     #[inline]
@@ -324,7 +324,7 @@ impl<T: num_traits::Float, RF> IntoIterator for Cartesian<T, RF> {
 }
 
 // --- IntoIterator for &Cartesian ---
-impl<'a, T: num_traits::Float, RF> IntoIterator for &'a Cartesian<T, RF> {
+impl<'a, T: Real, RF> IntoIterator for &'a Cartesian<T, RF> {
     type Item = &'a T;
     type IntoIter = <&'a Vector<T, 3> as IntoIterator>::IntoIter;
     #[inline]
@@ -334,7 +334,7 @@ impl<'a, T: num_traits::Float, RF> IntoIterator for &'a Cartesian<T, RF> {
 }
 
 // --- IntoIterator for &mut Cartesian ---
-impl<'a, T: num_traits::Float, RF> IntoIterator for &'a mut Cartesian<T, RF> {
+impl<'a, T: Real, RF> IntoIterator for &'a mut Cartesian<T, RF> {
     type Item = &'a mut T;
     type IntoIter = <&'a mut Vector<T, 3> as IntoIterator>::IntoIter;
     #[inline]
@@ -343,9 +343,9 @@ impl<'a, T: num_traits::Float, RF> IntoIterator for &'a mut Cartesian<T, RF> {
     }
 }
 // Iterator Helpers
-impl<T: num_traits::Float, RF> Cartesian<T, RF> {
+impl<T: Real, RF> Cartesian<T, RF> {
     /// Map each component to a new type, preserving the reference frame.
-    pub fn map<U: num_traits::Float, F>(self, f: F) -> Cartesian<U, RF>
+    pub fn map<U: Real, F>(self, f: F) -> Cartesian<U, RF>
     where
         F: FnMut(T) -> U,
     {
@@ -360,7 +360,7 @@ impl<T: num_traits::Float, RF> Cartesian<T, RF> {
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde")]
-impl<T: Float + Serialize, RF: ReferenceFrame> Serialize for Cartesian<T, RF> {
+impl<T: Real + Serialize, RF: ReferenceFrame> Serialize for Cartesian<T, RF> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -370,7 +370,7 @@ impl<T: Float + Serialize, RF: ReferenceFrame> Serialize for Cartesian<T, RF> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T: Float + Deserialize<'de>, RF: ReferenceFrame> Deserialize<'de> for Cartesian<T, RF> {
+impl<'de, T: Real + Deserialize<'de>, RF: ReferenceFrame> Deserialize<'de> for Cartesian<T, RF> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -387,7 +387,7 @@ impl<'de, T: Float + Deserialize<'de>, RF: ReferenceFrame> Deserialize<'de> for 
 use core::{fmt, num};
 impl<T, RF> fmt::Display for Cartesian<T, RF>
 where
-    T: Float + fmt::Display,
+    T: Real + fmt::Display,
     RF: ReferenceFrame,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/aether_core/src/coordinate/cylindrical.rs
+++ b/crates/aether_core/src/coordinate/cylindrical.rs
@@ -1,15 +1,14 @@
-use num_traits::Float;
-
 use super::cartesian::Cartesian;
 use super::spherical::Spherical;
 use crate::math::Vector;
 use crate::reference_frame::ReferenceFrame;
+use crate::real::Real;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Cylindrical<T: Float> {
+pub struct Cylindrical<T: Real> {
     pub data: Vector<T, 3>, // [r, theta, z]
 }
-impl<T: Float> Cylindrical<T> {
+impl<T: Real> Cylindrical<T> {
     pub fn new(r: T, theta: T, z: T) -> Self {
         Self {
             data: Vector {
@@ -28,7 +27,7 @@ impl<T: Float> Cylindrical<T> {
     }
 }
 
-impl<T: Float, RF: ReferenceFrame> From<&Cartesian<T, RF>> for Cylindrical<T> {
+impl<T: Real, RF: ReferenceFrame> From<&Cartesian<T, RF>> for Cylindrical<T> {
     fn from(cart: &Cartesian<T, RF>) -> Self {
         let x = cart.x();
         let y = cart.y();
@@ -39,7 +38,7 @@ impl<T: Float, RF: ReferenceFrame> From<&Cartesian<T, RF>> for Cylindrical<T> {
     }
 }
 
-impl<T: Float> From<&Spherical<T>> for Cylindrical<T> {
+impl<T: Real> From<&Spherical<T>> for Cylindrical<T> {
     fn from(s: &Spherical<T>) -> Self {
         let r = s.r() * s.theta().sin();
         let z = s.r() * s.theta().cos();

--- a/crates/aether_core/src/coordinate/mod.rs
+++ b/crates/aether_core/src/coordinate/mod.rs
@@ -10,9 +10,8 @@ pub mod coordinate {
         coordinate::{Cartesian, Cylindrical, Spherical},
         reference_frame::ReferenceFrame,
     };
-    use num_traits::Float;
-
-    pub enum Coordinate<T: Float, F: ReferenceFrame> {
+    use crate::real::Real;
+    pub enum Coordinate<T: Real, F: ReferenceFrame> {
         CartesianValue(Cartesian<T, F>),
         CylindricalValue(Cylindrical<T>),
         SphericalValue(Spherical<T>),

--- a/crates/aether_core/src/coordinate/spherical.rs
+++ b/crates/aether_core/src/coordinate/spherical.rs
@@ -1,18 +1,17 @@
-use num_traits::{Float, Pow};
-
+use crate::real::Real;
 use super::cartesian::Cartesian;
 use super::cylindrical::Cylindrical;
 use crate::{math::Vector, reference_frame::ReferenceFrame};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Spherical<T: Float> {
+pub struct Spherical<T: Real> {
     /// r: radial distance
     /// phi: azimuthal angle (radians, from +x in xy-plane)
     /// theta: inclination angle (radians (z-axis))
     pub data: Vector<T, 3>, // [r, phi, theta]
 }
 
-impl<T: Float> Spherical<T> {
+impl<T: Real> Spherical<T> {
     pub fn new(r: T, phi: T, theta: T) -> Self {
         Self {
             data: Vector {
@@ -31,15 +30,15 @@ impl<T: Float> Spherical<T> {
     }
 }
 
-impl<T: Float, RF: ReferenceFrame> From<&Cartesian<T, RF>> for Spherical<T> {
+impl<T: Real, RF: ReferenceFrame> From<&Cartesian<T, RF>> for Spherical<T> {
     fn from(cart: &Cartesian<T, RF>) -> Self {
         let x = cart.x();
         let y = cart.y();
         let z = cart.z();
         let rho = (x * x + y * y + z * z).sqrt();
         let theta = y.atan2(x); // azimuth angle in xy-plane
-        let phi = if rho == T::zero() {
-            T::zero()
+        let phi = if rho == T::ZERO {
+            T::ZERO
         } else {
             (z / rho).acos()
         }; // inclination from z-axis
@@ -47,17 +46,17 @@ impl<T: Float, RF: ReferenceFrame> From<&Cartesian<T, RF>> for Spherical<T> {
     }
 }
 
-impl<T: Float> From<&Cylindrical<T>> for Spherical<T> {
+impl<T: Real> From<&Cylindrical<T>> for Spherical<T> {
     fn from(c: &Cylindrical<T>) -> Self {
         let r_cyl = c.r();
         let theta = c.theta(); // azimuthal angle in x-y plane
         let z = c.z();
 
         let rho = (r_cyl * r_cyl + z * z).sqrt(); // spherical radius
-        let phi = if rho != T::zero() {
+        let phi = if rho != T::ZERO {
             (z / rho).acos() // inclination from z-axis
         } else {
-            T::zero()
+            T::ZERO
         };
         Spherical::new(rho, theta, phi)
     }

--- a/crates/aether_core/src/math/macros.rs
+++ b/crates/aether_core/src/math/macros.rs
@@ -51,19 +51,18 @@ pub(crate) use ones;
 
 // Vectors
 use crate::math::Vector;
-use num_traits::Float;
-impl<T, const N: usize> Vector<T, N>
+use crate::real::Real;impl<T, const N: usize> Vector<T, N>
 where
-    T: Float + Copy,
+    T: Real + Copy,
 {
     pub fn zeros() -> Self {
         Self {
-            data: [T::zero(); N],
+            data: [T::ZERO; N],
         }
     }
     pub fn ones() -> Self {
         Self {
-            data: [T::one(); N],
+            data: [T::ONE; N],
         }
     }
 }

--- a/crates/aether_core/src/numerical_methods/integration/euler.rs
+++ b/crates/aether_core/src/numerical_methods/integration/euler.rs
@@ -1,18 +1,17 @@
 use crate::coordinate::Cartesian;
 use crate::math::Vector;
-use num_traits::Float;
-
-pub trait EulerIntegrate<T: Float> {
+use crate::real::Real;
+pub trait EulerIntegrate<T: Real> {
     fn integrate_euler(&self, dt: T) -> Self;
 }
 
-impl<T: Float + Copy, const N: usize> EulerIntegrate<T> for Vector<T, N> {
+impl<T: Real + Copy, const N: usize> EulerIntegrate<T> for Vector<T, N> {
     fn integrate_euler(&self, dt: T) -> Self {
         *self * dt
     }
 }
 
-impl<T: Float + Copy, RF> EulerIntegrate<T> for Cartesian<T, RF> {
+impl<T: Real + Copy, RF> EulerIntegrate<T> for Cartesian<T, RF> {
     fn integrate_euler(&self, dt: T) -> Self {
         Cartesian {
             data: self.data * dt,

--- a/crates/aether_core/src/numerical_methods/integration/rk4.rs
+++ b/crates/aether_core/src/numerical_methods/integration/rk4.rs
@@ -1,9 +1,8 @@
 use crate::coordinate::Cartesian;
 use crate::math::Vector;
 use core::marker::PhantomData;
-use num_traits::Float;
-
-pub trait Rk4Integrate<T: Float> {
+use crate::real::Real;
+pub trait Rk4Integrate<T: Real> {
     /// RK4 step given `self` as the current state,
     /// `f` as the derivative function, and `dt` as the time step.
     fn integrate_rk4<F>(&self, f: F, dt: T) -> Self
@@ -11,25 +10,25 @@ pub trait Rk4Integrate<T: Float> {
         F: Fn(&Self) -> Self;
 }
 
-impl<T: Float + Copy, const N: usize> Rk4Integrate<T> for Vector<T, N> {
+impl<T: Real + Copy, const N: usize> Rk4Integrate<T> for Vector<T, N> {
     fn integrate_rk4<F>(&self, f: F, dt: T) -> Self
     where
         F: Fn(&Self) -> Self,
     {
         let k1 = f(self);
-        let k2 = f(&(*self + &k1 * (dt / T::from(2.0).unwrap())));
-        let k3 = f(&(*self + &k2 * (dt / T::from(2.0).unwrap())));
+        let k2 = f(&(*self + &k1 * (dt / T::from_f32(2.0))));
+        let k3 = f(&(*self + &k2 * (dt / T::from_f32(2.0))));
         let k4 = f(&(*self + &k3 * dt));
-        *self + (k1 + k2 + k2 + k3 + k3 + k4) * (dt / T::from(6.0).unwrap())
+        *self + (k1 + k2 + k2 + k3 + k3 + k4) * (dt / T::from_f32(6.0))
     }
 }
-impl<T: Float + Copy, RF> Rk4Integrate<T> for Cartesian<T, RF> {
+impl<T: Real + Copy, RF> Rk4Integrate<T> for Cartesian<T, RF> {
     fn integrate_rk4<F>(&self, f: F, dt: T) -> Self
     where
         F: Fn(&Self) -> Self,
     {
-        let half_dt = dt / T::from(2.0).unwrap();
-        let sixth_dt = dt / T::from(6.0).unwrap();
+        let half_dt = dt / T::from_f32(2.0);
+        let sixth_dt = dt / T::from_f32(6.0);
 
         let k1 = f(self);
         let k2 = f(&(self + &k1 * half_dt));
@@ -39,8 +38,8 @@ impl<T: Float + Copy, RF> Rk4Integrate<T> for Cartesian<T, RF> {
         Self {
             data: self.data
                 + (k1.data
-                    + k2.data * T::from(2.0).unwrap()
-                    + k3.data * T::from(2.0).unwrap()
+                    + k2.data * T::from_f32(2.0)
+                    + k3.data * T::from_f32(2.0)
                     + k4.data)
                     * sixth_dt,
             _reference_frame: PhantomData,

--- a/crates/aether_core/src/numerical_methods/integration/trapezoidal.rs
+++ b/crates/aether_core/src/numerical_methods/integration/trapezoidal.rs
@@ -1,8 +1,7 @@
 use crate::coordinate::Cartesian;
 use crate::math::Vector;
 use core::marker::PhantomData;
-use num_traits::Float;
-
+use crate::real::Real;
 pub trait TrapezoidalIntegrate {
     type Scalar;
 
@@ -10,18 +9,18 @@ pub trait TrapezoidalIntegrate {
     fn integrate_trapezoidal(&self, last: &Self, dt: Self::Scalar) -> Self;
 }
 
-impl<T: Float + Copy, const N: usize> TrapezoidalIntegrate for Vector<T, N> {
+impl<T: Real + Copy, const N: usize> TrapezoidalIntegrate for Vector<T, N> {
     type Scalar = T;
     fn integrate_trapezoidal(&self, last: &Self, dt: T) -> Self {
-        (*self + *last) * T::from(0.5).unwrap() * dt
+        (*self + *last) * T::from_f32(0.5) * dt
     }
 }
 
-impl<T: Float + Copy, RF> TrapezoidalIntegrate for Cartesian<T, RF> {
+impl<T: Real + Copy, RF> TrapezoidalIntegrate for Cartesian<T, RF> {
     type Scalar = T;
     fn integrate_trapezoidal(&self, last: &Self, dt: T) -> Self {
         Cartesian {
-            data: (self.data + last.data) * (T::from(0.5).unwrap()) * dt,
+            data: (self.data + last.data) * T::from_f32(0.5) * dt,
             _reference_frame: PhantomData,
         }
     }

--- a/crates/aether_core/src/numerical_methods/solvers/lu.rs
+++ b/crates/aether_core/src/numerical_methods/solvers/lu.rs
@@ -1,14 +1,14 @@
-use num_traits::Float;
+use crate::real::Real;
 use crate::math::{Matrix, Vector};
 
 #[derive(Debug, Clone, Copy)]
-pub struct LuDecomp<T: Float + Copy, const N: usize> {
+pub struct LuDecomp<T: Real + Copy, const N: usize> {
     pub lu: Matrix<T, N, N>,       // Combined L (unit diag) and U
     pub piv: [usize; N],           // Row permutations applied to A
     pub sign: i8,                  // +1 or -1 depending on parity
 }
 
-impl<T: Float + Copy, const N: usize> Matrix<T, N, N> {
+impl<T: Real + Copy, const N: usize> Matrix<T, N, N> {
     /// Compute LU with partial pivoting. A = P*L*U
     /// Returns None if numerically singular.
     pub fn lu_decompose(&self) -> Option<LuDecomp<T, N>> {
@@ -25,7 +25,7 @@ impl<T: Float + Copy, const N: usize> Matrix<T, N, N> {
                 let v = lu[(r, k)].abs();
                 if v > pval { p = r; pval = v; }
             }
-            if pval <= T::epsilon() { return None; } // singular
+            if pval <= T::EPSILON { return None; } // singular
 
             // Swap rows if needed
             if p != k {
@@ -54,11 +54,11 @@ impl<T: Float + Copy, const N: usize> Matrix<T, N, N> {
     }
 }
 
-impl<T: Float + Copy, const N: usize> LuDecomp<T, N> {
+impl<T: Real + Copy, const N: usize> LuDecomp<T, N> {
     /// Solve Ax=b using the LU factors (single RHS).
     pub fn solve(&self, b: &Vector<T, N>) -> Vector<T, N> {
         // Apply permutation to b -> Pb
-        let mut x = Vector { data: [T::zero(); N] };
+        let mut x = Vector { data: [T::ZERO; N] };
         for i in 0..N {
             x[i] = b[self.piv[i]];
         }
@@ -91,7 +91,7 @@ impl<T: Float + Copy, const N: usize> LuDecomp<T, N> {
 
         // Apply permutation P to each RHS column
         for col in 0..K {
-            let mut tmp = [T::zero(); N];
+            let mut tmp = [T::ZERO; N];
             for i in 0..N {
                 tmp[i] = x[self.piv[i]][col];
             }
@@ -128,7 +128,7 @@ impl<T: Float + Copy, const N: usize> LuDecomp<T, N> {
 }
 
 /// Convenience: A.solve(b) -> Option<x>
-impl<T: Float + Copy, const N: usize> Matrix<T, N, N> {
+impl<T: Real + Copy, const N: usize> Matrix<T, N, N> {
     pub fn solve(&self, b: &Vector<T, N>) -> Option<Vector<T, N>> {
         let lu = self.lu_decompose()?;
         Some(lu.solve(b))

--- a/crates/aether_core/src/numerical_methods/solvers/spd.rs
+++ b/crates/aether_core/src/numerical_methods/solvers/spd.rs
@@ -1,12 +1,12 @@
-use num_traits::Float;
+use crate::real::Real;
 use crate::math::{Matrix, Vector};
 
 #[derive(Debug, Clone, Copy)]
-pub struct CholLower<T: Float + Copy, const N: usize> {
+pub struct CholLower<T: Real + Copy, const N: usize> {
     pub l: Matrix<T, N, N>, // lower-triangular with positive diagonal
 }
 
-impl<T: Float + Copy, const N: usize> Matrix<T, N, N> {
+impl<T: Real + Copy, const N: usize> Matrix<T, N, N> {
     /// Compute lower Cholesky: A = L * L^t. Returns None if not SPD.
     pub fn cholesky_lower(&self) -> Option<CholLower<T, N>> {
         let mut l = Matrix::<T, N, N>::zeros();
@@ -17,7 +17,7 @@ impl<T: Float + Copy, const N: usize> Matrix<T, N, N> {
                     s = s - l[(i, k)] * l[(j, k)];
                 }
                 if i == j {
-                    if s <= T::zero() { return None; }
+                    if s <= T::ZERO { return None; }
                     l[(i, j)] = s.sqrt();
                 } else {
                     l[(i, j)] = s / l[(j, j)];
@@ -25,7 +25,7 @@ impl<T: Float + Copy, const N: usize> Matrix<T, N, N> {
             }
             // zero the strict upper part
             for j in (i + 1)..N {
-                l[(i, j)] = T::zero();
+                l[(i, j)] = T::ZERO;
             }
         }
 
@@ -33,7 +33,7 @@ impl<T: Float + Copy, const N: usize> Matrix<T, N, N> {
     }
 }
 
-impl<T: Float + Copy, const N: usize> CholLower<T, N> {
+impl<T: Real + Copy, const N: usize> CholLower<T, N> {
     /// Solve A x = b using Cholesky factors (A = L L^t).
     pub fn solve(&self, b: &Vector<T, N>) -> Vector<T, N> {
         let l = &self.l;
@@ -64,7 +64,7 @@ impl<T: Float + Copy, const N: usize> CholLower<T, N> {
 }
 
 /// Convenience: A.cholesky_solve(b)
-impl<T: Float + Copy, const N: usize> Matrix<T, N, N> {
+impl<T: Real + Copy, const N: usize> Matrix<T, N, N> {
     pub fn cholesky_solve(&self, b: &Vector<T, N>) -> Option<Vector<T, N>> {
         let chol = self.cholesky_lower()?;
         Some(chol.solve(b))

--- a/crates/aether_core/src/real/real.rs
+++ b/crates/aether_core/src/real/real.rs
@@ -17,9 +17,13 @@ pub trait Real:
     + Div<Output = Self>
     + Neg<Output = Self>
 {
-    const ZERO: Self;
-    const ONE:  Self;
-    const PI:   Self;
+    const ZERO:    Self;
+    const ONE:     Self;
+    const PI:      Self;
+    const FRAC_PI_2: Self;
+    const EPSILON: Self;
+    const INFINITY: Self;
+    const NEG_INFINITY: Self;
 
     // Conversions
     fn from_f32(x: f32) -> Self;
@@ -33,18 +37,54 @@ pub trait Real:
     #[cfg(feature = "f128")]
     fn from_f128(x: f128) -> Self;
 
-    // Will add as I use stuff...
+    // Basic math operations (re-exports)
     fn abs(self) -> Self;
-    fn cos(self) -> Self;
+    fn signum(self) -> Self;
+
+    fn floor(self) -> Self;
+    fn ceil(self) -> Self;
+    fn round(self) -> Self;
+    fn trunc(self) -> Self;
+    fn fract(self) -> Self;
+
+    fn min(self, other: Self) -> Self;
+    fn max(self, other: Self) -> Self;
+    fn copysign(self, sign: Self) -> Self;
+
+    fn sqrt(self) -> Self;
+
     fn sin(self) -> Self;
+    fn cos(self) -> Self;
+    fn tan(self) -> Self;
+
+    fn asin(self) -> Self;
+    fn acos(self) -> Self;
+    fn atan(self) -> Self;
+    fn atan2(self, other: Self) -> Self;
+
+    fn exp(self) -> Self;
+    fn exp2(self) -> Self;
+    fn ln(self) -> Self;
+    fn log2(self) -> Self;
+    fn log10(self) -> Self;
+
+    fn powi(self, n: i32) -> Self;
+    fn powf(self, n: Self) -> Self;
+
+    fn to_degrees(self) -> Self;
+    fn to_radians(self) -> Self;
 }
 
 /* -------------------- f32 -------------------- */
 
 impl Real for f32 {
-    const ZERO: Self = 0.0;
-    const ONE:  Self = 1.0;
-    const PI:   Self = core::f32::consts::PI;
+    const ZERO:    Self = 0.0;
+    const ONE:     Self = 1.0;
+    const PI:      Self = core::f32::consts::PI;
+    const FRAC_PI_2: Self = core::f32::consts::FRAC_PI_2;
+    const EPSILON: Self = core::f32::EPSILON;
+    const INFINITY: Self = core::f32::INFINITY;
+    const NEG_INFINITY: Self = core::f32::NEG_INFINITY;
 
     #[cfg(feature = "f16")]
     #[inline]
@@ -66,22 +106,53 @@ impl Real for f32 {
     #[inline]
     fn from_f128(x: f128) -> Self { x as f32 }
 
-    #[inline]
-    fn abs(self) -> Self { f32::abs(self) }
+    #[inline] fn abs(self) -> Self { f32::abs(self) }
+    #[inline] fn signum(self) -> Self { f32::signum(self) }
 
-    #[inline]
-    fn cos(self) -> Self { f32::cos(self) }
+    #[inline] fn floor(self) -> Self { f32::floor(self) }
+    #[inline] fn ceil(self) -> Self { f32::ceil(self) }
+    #[inline] fn round(self) -> Self { f32::round(self) }
+    #[inline] fn trunc(self) -> Self { f32::trunc(self) }
+    #[inline] fn fract(self) -> Self { f32::fract(self) }
 
-    #[inline]
-    fn sin(self) -> Self { f32::sin(self) }
+    #[inline] fn min(self, other: Self) -> Self { f32::min(self, other) }
+    #[inline] fn max(self, other: Self) -> Self { f32::max(self, other) }
+    #[inline] fn copysign(self, sign: Self) -> Self { f32::copysign(self, sign) }
+
+    #[inline] fn sqrt(self) -> Self { f32::sqrt(self) }
+
+    #[inline] fn sin(self) -> Self { f32::sin(self) }
+    #[inline] fn cos(self) -> Self { f32::cos(self) }
+    #[inline] fn tan(self) -> Self { f32::tan(self) }
+
+    #[inline] fn asin(self) -> Self { f32::asin(self) }
+    #[inline] fn acos(self) -> Self { f32::acos(self) }
+    #[inline] fn atan(self) -> Self { f32::atan(self) }
+    #[inline] fn atan2(self, other: Self) -> Self { f32::atan2(self, other) }
+
+    #[inline] fn exp(self) -> Self { f32::exp(self) }
+    #[inline] fn exp2(self) -> Self { f32::exp2(self) }
+    #[inline] fn ln(self) -> Self { f32::ln(self) }
+    #[inline] fn log2(self) -> Self { f32::log2(self) }
+    #[inline] fn log10(self) -> Self { f32::log10(self) }
+
+    #[inline] fn powi(self, n: i32) -> Self { f32::powi(self, n) }
+    #[inline] fn powf(self, n: Self) -> Self { f32::powf(self, n) }
+
+    #[inline] fn to_degrees(self) -> Self { f32::to_degrees(self) }
+    #[inline] fn to_radians(self) -> Self { f32::to_radians(self) }
 }
 
 /* -------------------- f64 -------------------- */
 
 impl Real for f64 {
-    const ZERO: Self = 0.0;
-    const ONE:  Self = 1.0;
-    const PI:   Self = core::f64::consts::PI;
+    const ZERO:    Self = 0.0;
+    const ONE:     Self = 1.0;
+    const PI:      Self = core::f64::consts::PI;
+    const FRAC_PI_2: Self = core::f64::consts::FRAC_PI_2;
+    const EPSILON: Self = core::f64::EPSILON;
+    const INFINITY: Self = core::f64::INFINITY;
+    const NEG_INFINITY: Self = core::f64::NEG_INFINITY;
 
     #[cfg(feature = "f16")]
     #[inline]
@@ -103,23 +174,54 @@ impl Real for f64 {
     #[inline]
     fn from_f128(x: f128) -> Self { x as f64 }
 
-    #[inline]
-    fn abs(self) -> Self { f64::abs(self) }
+    #[inline] fn abs(self) -> Self { f64::abs(self) }
+    #[inline] fn signum(self) -> Self { f64::signum(self) }
 
-    #[inline]
-    fn cos(self) -> Self { f64::cos(self) }
+    #[inline] fn floor(self) -> Self { f64::floor(self) }
+    #[inline] fn ceil(self) -> Self { f64::ceil(self) }
+    #[inline] fn round(self) -> Self { f64::round(self) }
+    #[inline] fn trunc(self) -> Self { f64::trunc(self) }
+    #[inline] fn fract(self) -> Self { f64::fract(self) }
 
-    #[inline]
-    fn sin(self) -> Self { f64::sin(self) }
+    #[inline] fn min(self, other: Self) -> Self { f64::min(self, other) }
+    #[inline] fn max(self, other: Self) -> Self { f64::max(self, other) }
+    #[inline] fn copysign(self, sign: Self) -> Self { f64::copysign(self, sign) }
+
+    #[inline] fn sqrt(self) -> Self { f64::sqrt(self) }
+
+    #[inline] fn sin(self) -> Self { f64::sin(self) }
+    #[inline] fn cos(self) -> Self { f64::cos(self) }
+    #[inline] fn tan(self) -> Self { f64::tan(self) }
+
+    #[inline] fn asin(self) -> Self { f64::asin(self) }
+    #[inline] fn acos(self) -> Self { f64::acos(self) }
+    #[inline] fn atan(self) -> Self { f64::atan(self) }
+    #[inline] fn atan2(self, other: Self) -> Self { f64::atan2(self, other) }
+
+    #[inline] fn exp(self) -> Self { f64::exp(self) }
+    #[inline] fn exp2(self) -> Self { f64::exp2(self) }
+    #[inline] fn ln(self) -> Self { f64::ln(self) }
+    #[inline] fn log2(self) -> Self { f64::log2(self) }
+    #[inline] fn log10(self) -> Self { f64::log10(self) }
+
+    #[inline] fn powi(self, n: i32) -> Self { f64::powi(self, n) }
+    #[inline] fn powf(self, n: Self) -> Self { f64::powf(self, n) }
+
+    #[inline] fn to_degrees(self) -> Self { f64::to_degrees(self) }
+    #[inline] fn to_radians(self) -> Self { f64::to_radians(self) }
 }
 
 /* -------------------- f16 -------------------- */
 
 #[cfg(feature = "f16")]
 impl Real for f16 {
-    const ZERO: Self = 0.0;
-    const ONE:  Self = 1.0;
-    const PI:   Self = core::f16::consts::PI;
+    const ZERO:    Self = 0.0;
+    const ONE:     Self = 1.0;
+    const PI:      Self = f16::consts::PI;
+    const FRAC_PI_2: Self = f16::consts::FRAC_PI_2;
+    const EPSILON: Self = f16::EPSILON;
+    const INFINITY: Self = f16::INFINITY;
+    const NEG_INFINITY: Self = f16::NEG_INFINITY;
 
     #[inline]
     fn from_f16(x: f16) -> Self { x }
@@ -140,23 +242,54 @@ impl Real for f16 {
     #[inline]
     fn from_f128(x: f128) -> Self { x as f16 }
 
-    #[inline]
-    fn abs(self) -> Self { self.abs() }
+    #[inline] fn abs(self) -> Self { self.abs() }
+    #[inline] fn signum(self) -> Self { self.signum() }
 
-    #[inline]
-    fn cos(self) -> Self { self.cos() }
+    #[inline] fn floor(self) -> Self { self.floor() }
+    #[inline] fn ceil(self) -> Self { self.ceil() }
+    #[inline] fn round(self) -> Self { self.round() }
+    #[inline] fn trunc(self) -> Self { self.trunc() }
+    #[inline] fn fract(self) -> Self { self.fract() }
 
-    #[inline]
-    fn sin(self) -> Self { self.sin() }
+    #[inline] fn min(self, other: Self) -> Self { self.min(other) }
+    #[inline] fn max(self, other: Self) -> Self { self.max(other) }
+    #[inline] fn copysign(self, sign: Self) -> Self { self.copysign(sign) }
+
+    #[inline] fn sqrt(self) -> Self { self.sqrt() }
+
+    #[inline] fn sin(self) -> Self { self.sin() }
+    #[inline] fn cos(self) -> Self { self.cos() }
+    #[inline] fn tan(self) -> Self { self.tan() }
+
+    #[inline] fn asin(self) -> Self { self.asin() }
+    #[inline] fn acos(self) -> Self { self.acos() }
+    #[inline] fn atan(self) -> Self { self.atan() }
+    #[inline] fn atan2(self, other: Self) -> Self { self.atan2(other) }
+
+    #[inline] fn exp(self) -> Self { self.exp() }
+    #[inline] fn exp2(self) -> Self { self.exp2() }
+    #[inline] fn ln(self) -> Self { self.ln() }
+    #[inline] fn log2(self) -> Self { self.log2() }
+    #[inline] fn log10(self) -> Self { self.log10() }
+
+    #[inline] fn powi(self, n: i32) -> Self { self.powi(n) }
+    #[inline] fn powf(self, n: Self) -> Self { self.powf(n) }
+
+    #[inline] fn to_degrees(self) -> Self { self.to_degrees() }
+    #[inline] fn to_radians(self) -> Self { self.to_radians() }
 }
 
 /* -------------------- f128 -------------------- */
 
 #[cfg(feature = "f128")]
 impl Real for f128 {
-    const ZERO: Self = 0.0;
-    const ONE:  Self = 1.0;
-    const PI:   Self = core::f128::consts::PI;
+    const ZERO:    Self = 0.0;
+    const ONE:     Self = 1.0;
+    const PI:      Self = f128::consts::PI;
+    const FRAC_PI_2: Self = f128::consts::FRAC_PI_2;
+    const EPSILON: Self = f128::EPSILON;
+    const INFINITY: Self = f128::INFINITY;
+    const NEG_INFINITY: Self = f128::NEG_INFINITY;
 
     #[cfg(feature = "f16")]
     #[inline]
@@ -177,12 +310,39 @@ impl Real for f128 {
     #[inline]
     fn from_f128(x: f128) -> Self { x }
 
-    #[inline]
-    fn abs(self) -> Self { self.abs() }
+    #[inline] fn abs(self) -> Self { self.abs() }
+    #[inline] fn signum(self) -> Self { self.signum() }
 
-    #[inline]
-    fn cos(self) -> Self { self.cos() }
+    #[inline] fn floor(self) -> Self { self.floor() }
+    #[inline] fn ceil(self) -> Self { self.ceil() }
+    #[inline] fn round(self) -> Self { self.round() }
+    #[inline] fn trunc(self) -> Self { self.trunc() }
+    #[inline] fn fract(self) -> Self { self.fract() }
 
-    #[inline]
-    fn sin(self) -> Self { self.sin() }
+    #[inline] fn min(self, other: Self) -> Self { self.min(other) }
+    #[inline] fn max(self, other: Self) -> Self { self.max(other) }
+    #[inline] fn copysign(self, sign: Self) -> Self { self.copysign(sign) }
+
+    #[inline] fn sqrt(self) -> Self { self.sqrt() }
+
+    #[inline] fn sin(self) -> Self { self.sin() }
+    #[inline] fn cos(self) -> Self { self.cos() }
+    #[inline] fn tan(self) -> Self { self.tan() }
+
+    #[inline] fn asin(self) -> Self { self.asin() }
+    #[inline] fn acos(self) -> Self { self.acos() }
+    #[inline] fn atan(self) -> Self { self.atan() }
+    #[inline] fn atan2(self, other: Self) -> Self { self.atan2(other) }
+
+    #[inline] fn exp(self) -> Self { self.exp() }
+    #[inline] fn exp2(self) -> Self { self.exp2() }
+    #[inline] fn ln(self) -> Self { self.ln() }
+    #[inline] fn log2(self) -> Self { self.log2() }
+    #[inline] fn log10(self) -> Self { self.log10() }
+
+    #[inline] fn powi(self, n: i32) -> Self { self.powi(n) }
+    #[inline] fn powf(self, n: Self) -> Self { self.powf(n) }
+
+    #[inline] fn to_degrees(self) -> Self { self.to_degrees() }
+    #[inline] fn to_radians(self) -> Self { self.to_radians() }
 }

--- a/crates/aether_core/src/reference_frame/asm.rs
+++ b/crates/aether_core/src/reference_frame/asm.rs
@@ -4,17 +4,16 @@
 //! inertial or world frames must be provided by the surrounding system.
 use crate::coordinate::Cartesian;
 use crate::reference_frame::{FixedFrame, ReferenceFrame};
-use num_traits::Float;
-
+use crate::real::Real;
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Assembly<T: Float> {
+pub struct Assembly<T: Real> {
     /// Vector from origin to center of mass in Assembly coordinates
     pub mass_center: Cartesian<T, Assembly<T>>,
     /// Vector from origin to sensor/actuator location (e.g., IMU offset)
     pub lever_arm: Cartesian<T, Assembly<T>>,
 }
 
-impl<T: Float> Assembly<T> {
+impl<T: Real> Assembly<T> {
     pub fn new(
         mass_center: Cartesian<T, Assembly<T>>,
         lever_arm: Cartesian<T, Assembly<T>>,
@@ -26,7 +25,7 @@ impl<T: Float> Assembly<T> {
     }
 }
 
-impl<T: Float + Default> Default for Assembly<T> {
+impl<T: Real + Default> Default for Assembly<T> {
     fn default() -> Self {
         Self {
             mass_center: Cartesian::default(),
@@ -36,10 +35,10 @@ impl<T: Float + Default> Default for Assembly<T> {
 }
 
 // Implement ReferenceFrame for Assembly<T>
-impl<T: Float> ReferenceFrame for Assembly<T> {}
+impl<T: Real> ReferenceFrame for Assembly<T> {}
 
 // Implement FixedFrame for Assembly<T>
-impl<T: Float> FixedFrame<T> for Assembly<T> {}
+impl<T: Real> FixedFrame<T> for Assembly<T> {}
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -47,7 +46,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "serde")]
 impl<T> Serialize for Assembly<T>
 where
-    T: Float + Serialize,
+    T: Real + Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -60,7 +59,7 @@ where
 #[cfg(feature = "serde")]
 impl<'de, T> Deserialize<'de> for Assembly<T>
 where
-    T: Float + Deserialize<'de>,
+    T: Real + Deserialize<'de>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/crates/aether_core/src/reference_frame/body.rs
+++ b/crates/aether_core/src/reference_frame/body.rs
@@ -4,17 +4,16 @@
 //! inertial or world frames must be provided by the surrounding system.
 use crate::coordinate::Cartesian;
 use crate::reference_frame::{FixedFrame, ReferenceFrame};
-use num_traits::Float;
-
+use crate::real::Real;
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Body<T: Float> {
+pub struct Body<T: Real> {
     /// Vector from origin to center of mass in body coordinates
     pub mass_center: Cartesian<T, Body<T>>,
     /// Vector from origin to sensor/actuator location (e.g., IMU offset)
     pub lever_arm: Cartesian<T, Body<T>>,
 }
 
-impl<T: Float> Body<T> {
+impl<T: Real> Body<T> {
     pub fn new(mass_center: Cartesian<T, Body<T>>, lever_arm: Cartesian<T, Body<T>>) -> Self {
         Self {
             mass_center: mass_center,
@@ -23,7 +22,7 @@ impl<T: Float> Body<T> {
     }
 }
 
-impl<T: Float + Default> Default for Body<T> {
+impl<T: Real + Default> Default for Body<T> {
     fn default() -> Self {
         Self {
             mass_center: Cartesian::default(),
@@ -33,10 +32,10 @@ impl<T: Float + Default> Default for Body<T> {
 }
 
 // Implement ReferenceFrame for Body<T>
-impl<T: Float> ReferenceFrame for Body<T> {}
+impl<T: Real> ReferenceFrame for Body<T> {}
 
 // Implement FixedFrame for Body<T>
-impl<T: Float> FixedFrame<T> for Body<T> {}
+impl<T: Real> FixedFrame<T> for Body<T> {}
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -44,7 +43,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "serde")]
 impl<T> Serialize for Body<T>
 where
-    T: Float + Serialize,
+    T: Real + Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -57,7 +56,7 @@ where
 #[cfg(feature = "serde")]
 impl<'de, T> Deserialize<'de> for Body<T>
 where
-    T: Float + Deserialize<'de>,
+    T: Real + Deserialize<'de>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/crates/aether_core/src/reference_frame/icrf.rs
+++ b/crates/aether_core/src/reference_frame/icrf.rs
@@ -1,11 +1,10 @@
 use crate::coordinate::Cartesian;
 use crate::reference_frame::ReferenceFrame;
-use num_traits::Float;
-
+use crate::real::Real;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct ICRF<T: Float> {
+pub struct ICRF<T: Real> {
     pub epoch: T,
 }
 
-impl<T: Float> ReferenceFrame for ICRF<T> {}
+impl<T: Real> ReferenceFrame for ICRF<T> {}

--- a/crates/aether_core/src/reference_frame/itrf.rs
+++ b/crates/aether_core/src/reference_frame/itrf.rs
@@ -3,20 +3,19 @@ use crate::coordinate::Cartesian;
 use crate::math::Vector;
 use crate::reference_frame::{ReferenceFrame, RotatingFrame};
 use core::marker::PhantomData;
-use num_traits::Float;
-
+use crate::real::Real;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Default, Clone, Copy)]
-pub struct ITRF<T: Float> {
+pub struct ITRF<T: Real> {
     pub epoch: T,
 }
 
-impl<T: Float> ReferenceFrame for ITRF<T> {}
+impl<T: Real> ReferenceFrame for ITRF<T> {}
 
-impl<T: Float> RotatingFrame<T, ITRF<T>> for ITRF<T> {
+impl<T: Real> RotatingFrame<T, ITRF<T>> for ITRF<T> {
     fn angular_velocity(&self) -> Cartesian<T, ITRF<T>> {
         Cartesian {
-            data: Vector::new([T::zero(), T::zero(), T::from(7.2921150e-5).unwrap()]),
+            data: Vector::new([T::ZERO, T::ZERO, T::from_f64(7.2921150e-5)]),
             _reference_frame: PhantomData,
         }
     }
@@ -26,12 +25,12 @@ impl<T: Float> RotatingFrame<T, ITRF<T>> for ITRF<T> {
     }
 
     fn orientation_at(&self, t: T) -> Quaternion<T> {
-        let omega = T::from(7.2921150e-5).unwrap(); // Earth's rotation rate [rad/s] (ITRF is actually more complicated and comes from ephermerides, more on that later...)
-        let dtheta = omega * (t - self.epoch);
-        let half_theta = dtheta * T::from(0.5).unwrap();
+        let omega = T::from_f64(7.2921150e-5); // Earth's rotation rate [rad/s] (ITRF is actually more complicated and comes from ephermerides, more on that later...)
+        let dtheta = (t - self.epoch) * omega;
+        let half_theta = dtheta * T::from_f32(0.5);
 
         Quaternion {
-            data: Vector::new([half_theta.cos(), T::zero(), T::zero(), half_theta.sin()]),
+            data: Vector::new([half_theta.cos(), T::ZERO, T::ZERO, half_theta.sin()]),
         }
     }
 }

--- a/crates/aether_core/src/reference_frame/ned.rs
+++ b/crates/aether_core/src/reference_frame/ned.rs
@@ -1,13 +1,12 @@
 use crate::coordinate::Cartesian;
 use crate::reference_frame::{FixedFrame, ReferenceFrame};
-use num_traits::Float;
-
+use crate::real::Real;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct NED<T: Float> {
+pub struct NED<T: Real> {
     pub origin: T,
 }
 
-impl<T: Float> ReferenceFrame for NED<T> {}
+impl<T: Real> ReferenceFrame for NED<T> {}
 
-impl<T: Float> FixedFrame<T> for NED<T> {}
+impl<T: Real> FixedFrame<T> for NED<T> {}

--- a/crates/aether_core/src/reference_frame/pose.rs
+++ b/crates/aether_core/src/reference_frame/pose.rs
@@ -2,21 +2,20 @@ use crate::attitude::DirectionCosineMatrix;
 use crate::coordinate::Cartesian;
 use crate::math::Matrix;
 use crate::reference_frame::{Assembly, ReferenceFrame};
-use num_traits::Float;
-
+use crate::real::Real;
 #[derive(Debug, Clone, Copy)]
-pub struct Pose<T: Float, From: ReferenceFrame> {
+pub struct Pose<T: Real, From: ReferenceFrame> {
     /// DCM from the solid's Local frame to the Assembly frame (Local -> Assembly)
     pub R_local_to_assembly: DirectionCosineMatrix<T, From, Assembly<T>>,
     /// Center-of-mass position in the Assembly frame
     pub r_cm_in_assembly: Cartesian<T, Assembly<T>>,
 }
 
-impl<T: Float, From: ReferenceFrame> Pose<T, From> {
+impl<T: Real, From: ReferenceFrame> Pose<T, From> {
     pub fn identity() -> Self {
         Self {
             R_local_to_assembly: DirectionCosineMatrix::from_matrix(Matrix::<T, 3, 3>::identity()),
-            r_cm_in_assembly: Cartesian::zero(),
+            r_cm_in_assembly: Cartesian::<T, Assembly<T>>::zero(),
         }
     }
 }

--- a/crates/aether_core/src/reference_frame/traits.rs
+++ b/crates/aether_core/src/reference_frame/traits.rs
@@ -1,16 +1,15 @@
 use crate::attitude::Quaternion;
 use crate::coordinate::Cartesian;
 use crate::math::Vector;
-use num_traits::Float;
-
+use crate::real::Real;
 /// Marker trait for any frame (inertial or rotating)
 pub trait ReferenceFrame {}
 
 /// Trait for fixed (non-rotating) frames
-pub trait FixedFrame<T: Float>: ReferenceFrame {}
+pub trait FixedFrame<T: Real>: ReferenceFrame {}
 
 /// Trait for rotating frames with time-dependent orientation
-pub trait RotatingFrame<T: Float, RF: ReferenceFrame> {
+pub trait RotatingFrame<T: Real, RF: ReferenceFrame> {
     /// Angular velocity in the body-fixed frame
     fn angular_velocity(&self) -> Cartesian<T, RF>;
 
@@ -22,6 +21,6 @@ pub trait RotatingFrame<T: Float, RF: ReferenceFrame> {
 }
 
 /// Trait for computing the rotation from `FROM` to `TO`
-pub trait RotationBetween<T: Float, FROM: ReferenceFrame, TO: ReferenceFrame> {
+pub trait RotationBetween<T: Real, FROM: ReferenceFrame, TO: ReferenceFrame> {
     fn rotation(t: T) -> Quaternion<T>;
 }

--- a/crates/aether_core/src/reference_frame/transforms.rs
+++ b/crates/aether_core/src/reference_frame/transforms.rs
@@ -3,8 +3,7 @@ use crate::coordinate::Cartesian;
 use crate::math::{Matrix, Vector};
 use crate::matrix;
 use crate::reference_frame::{Body, ReferenceFrame, ICRF, ITRF, NED};
-use num_traits::Float;
-
+use crate::real::Real;
 pub fn angular_rate_dcm(roll: f64, pitch: f64, yaw: f64) -> Matrix<f64, 3, 3> {
     let rotation_matrix = matrix![
         0.0, -yaw, pitch;

--- a/crates/aether_core/src/utils/angle_conversion.rs
+++ b/crates/aether_core/src/utils/angle_conversion.rs
@@ -10,7 +10,7 @@ pub trait ToDegrees {
     fn to_degrees(self) -> Self::Output;
 }
 
-// Implementations for primitive floats
+// Implementations for primitive Reals
 
 impl ToRadians for f32 {
     type Output = f32;

--- a/crates/aether_graphics/src/cameras/orbit_camera.rs
+++ b/crates/aether_graphics/src/cameras/orbit_camera.rs
@@ -1,10 +1,11 @@
 use aether_core::math::Vector;
 use aether_core::reference_frame::ReferenceFrame;
+use aether_core::real::Real;
 
 // 1) Define a phantom camera frame
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Camera<T: num_traits::Float>(core::marker::PhantomData<T>);
-impl<T: num_traits::Float> ReferenceFrame for Camera<T> {}
+pub struct Camera<T: Real>(core::marker::PhantomData<T>);
+impl<T: Real> ReferenceFrame for Camera<T> {}
 
 #[derive(Debug, Clone)]
 pub struct OrbitCamera {

--- a/crates/aether_graphics/src/graphics/transforms.rs
+++ b/crates/aether_graphics/src/graphics/transforms.rs
@@ -2,9 +2,9 @@ use aether_core::attitude::DirectionCosineMatrix;
 use aether_core::coordinate::Cartesian;
 use aether_core::math::{Matrix, Vector};
 use aether_core::reference_frame::ReferenceFrame;
-use num_traits::Float;
+use aether_core::real::Real;
 
-pub fn look_at<T: Float, F: ReferenceFrame>(
+pub fn look_at<T: Real, F: ReferenceFrame>(
     eye: &Cartesian<T, F>,
     center: &Cartesian<T, F>,
     up: &Cartesian<T, F>,
@@ -17,34 +17,34 @@ pub fn look_at<T: Float, F: ReferenceFrame>(
         [r[0], r[1], r[2], -r.dot(&eye.data)],
         [u[0], u[1], u[2], -u.dot(&eye.data)],
         [-f[0], -f[1], -f[2], f.dot(&eye.data)],
-        [T::zero(), T::zero(), T::zero(), T::one()],
+        [T::ZERO, T::ZERO, T::ZERO, T::ONE],
     ])
 }
 
-pub fn perspective<T: Float>(aspect: T, fov_y_rad: T, near: T, far: T) -> Matrix<T, 4, 4> {
-    // assert!(aspect > T::zero(), "Aspect ratio must be > 0");
-    // assert!(fov_y_rad > T::zero(), "Field of view must be > 0");
+pub fn perspective<T: Real>(aspect: T, fov_y_rad: T, near: T, far: T) -> Matrix<T, 4, 4> {
+    // assert!(aspect > T::ZERO, "Aspect ratio must be > 0");
+    // assert!(fov_y_rad > T::ZERO, "Field of view must be > 0");
     // assert!(near != far, "Near and far planes must not be equal");
 
-    let f = T::one() / (fov_y_rad / T::from(2.0).unwrap()).tan();
-    let nf = T::one() / (near - far);
+    let f = T::ONE / (fov_y_rad / T::from_f32(2.0)).tan();
+    let nf = T::ONE / (near - far);
 
     Matrix {
         data: [
-            [f / aspect, T::zero(), T::zero(), T::zero()],
-            [T::zero(), f, T::zero(), T::zero()],
-            [T::zero(), T::zero(), (far + near) * nf, -T::one()],
+            [f / aspect, T::ZERO, T::ZERO, T::ZERO],
+            [T::ZERO, f, T::ZERO, T::ZERO],
+            [T::ZERO, T::ZERO, (far + near) * nf, -T::ONE],
             [
-                T::zero(),
-                T::zero(),
-                (T::from(2.0).unwrap() * far * near) * nf,
-                T::zero(),
+                T::ZERO,
+                T::ZERO,
+                (T::from_f32(2.0) * far * near) * nf,
+                T::ZERO,
             ],
         ],
     }
 }
 
-pub fn look_at_perspective<T: Float, F: ReferenceFrame>(
+pub fn look_at_perspective<T: Real, F: ReferenceFrame>(
     eye: &Cartesian<T, F>,
     center: &Cartesian<T, F>,
     up: &Cartesian<T, F>,
@@ -58,7 +58,7 @@ pub fn look_at_perspective<T: Float, F: ReferenceFrame>(
     (view, projection)
 }
 
-pub fn translate<T: Float>(mat: &Matrix<T, 4, 4>, trans: &Vector<T, 3>) -> Matrix<T, 4, 4> {
+pub fn translate<T: Real>(mat: &Matrix<T, 4, 4>, trans: &Vector<T, 3>) -> Matrix<T, 4, 4> {
     let mut result = *mat;
 
     // Row-major translation: update the last column (row 0–2, col 3)

--- a/crates/aether_ml/src/classification/perceptron.rs
+++ b/crates/aether_ml/src/classification/perceptron.rs
@@ -1,22 +1,22 @@
 #![cfg(feature = "std")]
 use aether_core::math::Vector;
 use aether_opt::gradient_descent::GradientDescentGeneric;
-use num_traits::{cast::cast, Float};
+use aether_core::real::Real;
 
 /// Classic perceptron for binary classification on fixed-size feature vectors.
 #[derive(Clone, Copy, Debug)]
-pub struct Perceptron<F: Float + Copy, const N: usize> {
+pub struct Perceptron<F: Real + Copy, const N: usize> {
     pub weights: Vector<F, N>,
     pub bias: F,
     pub lr: F,
 }
 
-impl<F: Float + Copy, const N: usize> Perceptron<F, N> {
+impl<F: Real + Copy, const N: usize> Perceptron<F, N> {
     pub fn new() -> Self {
         Self {
-            weights: Vector::new([F::zero(); N]),
-            bias: F::zero(),
-            lr: F::one(),
+            weights: Vector::new([F::ZERO; N]),
+            bias: F::ZERO,
+            lr: F::ONE,
         }
     }
 
@@ -28,7 +28,7 @@ impl<F: Float + Copy, const N: usize> Perceptron<F, N> {
         s
     }
     pub fn predict(&self, x: &Vector<F, N>) -> i8 {
-        if self.predict_raw(x) >= F::zero() {
+        if self.predict_raw(x) >= F::ZERO {
             1
         } else {
             -1
@@ -39,8 +39,8 @@ impl<F: Float + Copy, const N: usize> Perceptron<F, N> {
     pub fn train_epoch(&mut self, x_data: &[Vector<F, N>], y: &[i8]) {
         for (x, &label) in x_data.iter().zip(y.iter()) {
             let pred = self.predict_raw(x);
-            let lab_f: F = if label >= 0 { F::one() } else { -F::one() };
-            if lab_f * pred <= F::zero() {
+            let lab_f: F = if label >= 0 { F::ONE } else { -F::ONE };
+            if lab_f * pred <= F::ZERO {
                 // mistaken
                 for i in 0..N {
                     self.weights[i] = self.weights[i] + self.lr * lab_f * x[i];
@@ -62,8 +62,8 @@ impl<F: Float + Copy, const N: usize> Perceptron<F, N> {
         if m_usize == 0 {
             return;
         }
-        let m: F = cast(m_usize).unwrap();
-        let mut p_arr: [F; M] = [F::zero(); M];
+        let m: F = F::from_usize(m_usize);
+        let mut p_arr: [F; M] = [F::ZERO; M];
         for i in 0..N {
             p_arr[i] = self.weights[i];
         }
@@ -72,15 +72,15 @@ impl<F: Float + Copy, const N: usize> Perceptron<F, N> {
 
         let f = move |pv: &Vector<F, M>| -> F {
             // perceptron loss: sum(max(0, -y * (w·x + b)))
-            let mut loss = F::zero();
+            let mut loss = F::ZERO;
             for (x, &yi) in x_data.iter().zip(y.iter()) {
                 let mut s = pv[N];
                 for i in 0..N {
                     s = s + pv[i] * x[i];
                 }
-                let yi_f: F = if yi >= 0 { F::one() } else { -F::one() };
+                let yi_f: F = if yi >= 0 { F::ONE } else { -F::ONE };
                 let val = -yi_f * s;
-                if val > F::zero() {
+                if val > F::ZERO {
                     loss = loss + val;
                 }
             }
@@ -88,15 +88,15 @@ impl<F: Float + Copy, const N: usize> Perceptron<F, N> {
         };
 
         let g = move |pv: &Vector<F, M>| -> Vector<F, M> {
-            let mut grads: [F; M] = [F::zero(); M];
+            let mut grads: [F; M] = [F::ZERO; M];
             for (x, &yi) in x_data.iter().zip(y.iter()) {
                 let mut s = pv[N];
                 for i in 0..N {
                     s = s + pv[i] * x[i];
                 }
-                let yi_f: F = if yi >= 0 { F::one() } else { -F::one() };
+                let yi_f: F = if yi >= 0 { F::ONE } else { -F::ONE };
                 let val = -yi_f * s;
-                if val > F::zero() {
+                if val > F::ZERO {
                     for i in 0..N {
                         grads[i] = grads[i] + -yi_f * x[i];
                     }

--- a/crates/aether_ml/src/regression/linear.rs
+++ b/crates/aether_ml/src/regression/linear.rs
@@ -1,23 +1,23 @@
 #![cfg(feature = "std")]
 use aether_core::math::Vector;
 use aether_opt::gradient_descent::GradientDescentGeneric;
-use num_traits::{cast::cast, Float};
+use aether_core::real::Real;
 
 /// Ordinary Least Squares via batch gradient descent for fixed-size features
 #[derive(Clone, Copy, Debug)]
-pub struct LinearRegression<F: Float + Copy, const N: usize> {
+pub struct LinearRegression<F: Real + Copy, const N: usize> {
     pub weights: Vector<F, N>,
     pub bias: F,
     pub lr: F,
 }
 
-impl<F: Float + Copy, const N: usize> LinearRegression<F, N> {
+impl<F: Real + Copy, const N: usize> LinearRegression<F, N> {
     pub fn new() -> Self {
         // Neutral default learning rate: 1 (callers/tests should set a smaller lr if desired)
         Self {
-            weights: Vector::new([F::zero(); N]),
-            bias: F::zero(),
-            lr: F::one(),
+            weights: Vector::new([F::ZERO; N]),
+            bias: F::ZERO,
+            lr: F::ONE,
         }
     }
 
@@ -35,10 +35,10 @@ impl<F: Float + Copy, const N: usize> LinearRegression<F, N> {
         if m_usize == 0 {
             return;
         }
-        let m: F = cast(m_usize).unwrap();
+        let m: F = F::from_usize(m_usize);
 
-        let mut grad_w = Vector::new([F::zero(); N]);
-        let mut grad_b = F::zero();
+        let mut grad_w = Vector::new([F::ZERO; N]);
+        let mut grad_b = F::ZERO;
 
         for (x, &yi) in x_data.iter().zip(y.iter()) {
             let pred = self.predict(x);
@@ -49,7 +49,7 @@ impl<F: Float + Copy, const N: usize> LinearRegression<F, N> {
             grad_b = grad_b + err;
         }
 
-        let two = F::one() + F::one();
+        let two = F::ONE + F::ONE;
         for i in 0..N {
             self.weights[i] = self.weights[i] - self.lr * (two * grad_w[i] / m);
         }
@@ -69,20 +69,20 @@ impl<F: Float + Copy, const N: usize> LinearRegression<F, N> {
         if m_usize == 0 {
             return;
         }
-        let m: F = cast(m_usize).unwrap();
+        let m: F = F::from_usize(m_usize);
 
         // initial param vector
-        let mut p_arr: [F; M] = [F::zero(); M];
+        let mut p_arr: [F; M] = [F::ZERO; M];
         for i in 0..N {
             p_arr[i] = self.weights[i];
         }
         p_arr[N] = self.bias;
         let x0 = Vector::new(p_arr);
-        let two = F::one() + F::one();
+        let two = F::ONE + F::ONE;
 
         let f = |pv: &Vector<F, M>| -> F {
             // unpack
-            let mut loss = F::zero();
+            let mut loss = F::ZERO;
             for (x, &yi) in x_data.iter().zip(y.iter()) {
                 let mut pred = pv[N];
                 for i in 0..N {
@@ -95,7 +95,7 @@ impl<F: Float + Copy, const N: usize> LinearRegression<F, N> {
         };
 
         let g = |pv: &Vector<F, M>| -> Vector<F, M> {
-            let mut grads: [F; M] = [F::zero(); M];
+            let mut grads: [F; M] = [F::ZERO; M];
             for (x, &yi) in x_data.iter().zip(y.iter()) {
                 let mut pred = pv[N];
                 for i in 0..N {

--- a/crates/aether_ml/src/regression/logistic.rs
+++ b/crates/aether_ml/src/regression/logistic.rs
@@ -1,31 +1,31 @@
 #![cfg(feature = "std")]
 use aether_core::math::Vector;
 use aether_opt::gradient_descent::GradientDescentGeneric;
-use num_traits::{cast::cast, Float};
+use aether_core::real::{Real};
 use std::vec::Vec;
 
 /// Simple logistic regression for small fixed-size feature vectors.
-/// Generic over N (number of features) and float type F.
+/// Generic over N (number of features) and Real type F.
 #[derive(Clone, Copy, Debug)]
-pub struct LogisticRegression<F: Float + Copy, const N: usize> {
+pub struct LogisticRegression<F: Real + Copy, const N: usize> {
     pub weights: Vector<F, N>,
     pub bias: F,
     pub lr: F,
 }
 
-impl<F: Float + Copy, const N: usize> LogisticRegression<F, N> {
+impl<F: Real + Copy, const N: usize> LogisticRegression<F, N> {
     pub fn new() -> Self {
         Self {
-            weights: Vector::new([F::zero(); N]),
-            bias: F::zero(),
+            weights: Vector::new([F::ZERO; N]),
+            bias: F::ZERO,
             // neutral default lr
-            lr: F::one(),
+            lr: F::ONE,
         }
     }
 
     #[inline]
     fn sigmoid(x: F) -> F {
-        F::one() / (F::one() + (-x).exp())
+        F::ONE / (F::ONE + (-x).exp())
     }
 
     /// Predict probability for a single example
@@ -39,7 +39,7 @@ impl<F: Float + Copy, const N: usize> LogisticRegression<F, N> {
 
     /// Predict 0/1 label
     pub fn predict(&self, x: &Vector<F, N>) -> u8 {
-        if self.predict_probability(x) > (F::one() / (F::one() + F::one())) {
+        if self.predict_probability(x) > (F::ONE / (F::ONE + F::ONE)) {
             1
         } else {
             0
@@ -53,14 +53,14 @@ impl<F: Float + Copy, const N: usize> LogisticRegression<F, N> {
         if m_usize == 0 {
             return;
         }
-        let m: F = cast(m_usize).unwrap();
+        let m: F = F::from_usize(m_usize);
 
-        let mut grad_w = Vector::new([F::zero(); N]);
-        let mut grad_b = F::zero();
+        let mut grad_w = Vector::new([F::ZERO; N]);
+        let mut grad_b = F::ZERO;
 
         for (x, &label) in x_data.iter().zip(y.iter()) {
             let p = self.predict_probability(x);
-            let y_f: F = if label == 0 { F::zero() } else { F::one() };
+            let y_f: F = if label == 0 { F::ZERO } else { F::ONE };
             let err = p - y_f;
             for i in 0..N {
                 grad_w[i] = grad_w[i] + err * x[i];
@@ -86,40 +86,40 @@ impl<F: Float + Copy, const N: usize> LogisticRegression<F, N> {
         if m_usize == 0 {
             return;
         }
-        let m: F = cast(m_usize).unwrap();
-        let mut p_arr: [F; M] = [F::zero(); M];
+        let m: F = F::from_usize(m_usize);
+        let mut p_arr: [F; M] = [F::ZERO; M];
         for i in 0..N {
             p_arr[i] = self.weights[i];
         }
         p_arr[N] = self.bias;
         let x0 = Vector::new(p_arr);
 
-        let tiny = F::one() / (F::one() + (F::one() + F::one()));
+        let tiny = F::ONE / (F::ONE + (F::ONE + F::ONE));
 
         let f = |pv: &Vector<F, M>| -> F {
-            let mut loss = F::zero();
+            let mut loss = F::ZERO;
             for (x, &yi) in x_data.iter().zip(y.iter()) {
                 let mut s = pv[N];
                 for i in 0..N {
                     s = s + pv[i] * x[i];
                 }
-                let p = F::one() / (F::one() + (-s).exp());
-                let yv: F = if yi == 0 { F::zero() } else { F::one() };
+                let p = F::ONE / (F::ONE + (-s).exp());
+                let yv: F = if yi == 0 { F::ZERO } else { F::ONE };
                 // binary cross-entropy: -(y ln p + (1-y) ln (1-p))
-                loss = loss - (yv * (p + tiny).ln() + (F::one() - yv) * (F::one() - p + tiny).ln());
+                loss = loss - (yv * (p + tiny).ln() + (F::ONE - yv) * (F::ONE - p + tiny).ln());
             }
             loss / m
         };
 
         let g = |pv: &Vector<F, M>| -> Vector<F, M> {
-            let mut grads: [F; M] = [F::zero(); M];
+            let mut grads: [F; M] = [F::ZERO; M];
             for (x, &yi) in x_data.iter().zip(y.iter()) {
                 let mut s = pv[N];
                 for i in 0..N {
                     s = s + pv[i] * x[i];
                 }
-                let p = F::one() / (F::one() + (-s).exp());
-                let e = p - if yi == 0 { F::zero() } else { F::one() };
+                let p = F::ONE / (F::ONE + (-s).exp());
+                let e = p - if yi == 0 { F::ZERO } else { F::ONE };
                 for i in 0..N {
                     grads[i] = grads[i] + e * x[i];
                 }

--- a/crates/aether_ml/src/regression/ridge.rs
+++ b/crates/aether_ml/src/regression/ridge.rs
@@ -1,25 +1,25 @@
 #![cfg(feature = "std")]
 use aether_core::math::Vector;
 use aether_opt::gradient_descent::GradientDescentGeneric;
-use num_traits::{cast::cast, Float};
+use aether_core::real::Real;
 
 /// Ridge regression (L2) using batch gradient descent
 #[derive(Clone, Copy, Debug)]
-pub struct RidgeRegression<F: Float + Copy, const N: usize> {
+pub struct RidgeRegression<F: Real + Copy, const N: usize> {
     pub weights: Vector<F, N>,
     pub bias: F,
     pub lr: F,
     pub alpha: F,
 }
 
-impl<F: Float + Copy, const N: usize> RidgeRegression<F, N> {
+impl<F: Real + Copy, const N: usize> RidgeRegression<F, N> {
     pub fn new() -> Self {
         // Neutral defaults: lr = 1, alpha = 1 (caller should set typical small lr/alpha)
         Self {
-            weights: Vector::new([F::zero(); N]),
-            bias: F::zero(),
-            lr: F::one(),
-            alpha: F::one(),
+            weights: Vector::new([F::ZERO; N]),
+            bias: F::ZERO,
+            lr: F::ONE,
+            alpha: F::ONE,
         }
     }
 
@@ -36,10 +36,10 @@ impl<F: Float + Copy, const N: usize> RidgeRegression<F, N> {
         if m_usize == 0 {
             return;
         }
-        let m: F = cast(m_usize).unwrap();
+        let m: F = F::from_usize(m_usize);
 
-        let mut grad_w = Vector::new([F::zero(); N]);
-        let mut grad_b = F::zero();
+        let mut grad_w = Vector::new([F::ZERO; N]);
+        let mut grad_b = F::ZERO;
 
         for (x, &yi) in x_data.iter().zip(y.iter()) {
             let pred = self.predict(x);
@@ -50,7 +50,7 @@ impl<F: Float + Copy, const N: usize> RidgeRegression<F, N> {
             grad_b = grad_b + err;
         }
 
-        let two = F::one() + F::one();
+        let two = F::ONE + F::ONE;
         for i in 0..N {
             // L2 term gradient: 2*alpha*w
             self.weights[i] = self.weights[i]
@@ -71,17 +71,17 @@ impl<F: Float + Copy, const N: usize> RidgeRegression<F, N> {
         if m_usize == 0 {
             return;
         }
-        let m: F = cast(m_usize).unwrap();
-        let mut p_arr: [F; M] = [F::zero(); M];
+        let m: F = F::from_usize(m_usize);
+        let mut p_arr: [F; M] = [F::ZERO; M];
         for i in 0..N {
             p_arr[i] = self.weights[i];
         }
         p_arr[N] = self.bias;
         let x0 = Vector::new(p_arr);
         let alpha = self.alpha;
-        let two = F::one() + F::one();
+        let two = F::ONE + F::ONE;
         let f = move |pv: &Vector<F, M>| -> F {
-            let mut loss = F::zero();
+            let mut loss = F::ZERO;
             for (x, &yi) in x_data.iter().zip(y.iter()) {
                 let mut pred = pv[N];
                 for i in 0..N {
@@ -91,7 +91,7 @@ impl<F: Float + Copy, const N: usize> RidgeRegression<F, N> {
                 loss = loss + e * e;
             }
             // L2 regularizer (alpha * ||w||^2)
-            let mut rw = F::zero();
+            let mut rw = F::ZERO;
             for i in 0..N {
                 rw = rw + pv[i] * pv[i];
             }
@@ -99,7 +99,7 @@ impl<F: Float + Copy, const N: usize> RidgeRegression<F, N> {
         };
 
         let g = move |pv: &Vector<F, M>| -> Vector<F, M> {
-            let mut grads: [F; M] = [F::zero(); M];
+            let mut grads: [F; M] = [F::ZERO; M];
             for (x, &yi) in x_data.iter().zip(y.iter()) {
                 let mut pred = pv[N];
                 for i in 0..N {

--- a/crates/aether_shapes/src/cylinder.rs
+++ b/crates/aether_shapes/src/cylinder.rs
@@ -1,39 +1,39 @@
 use crate::attributes::Solid;
 use aether_core::{math::Vector, reference_frame::ReferenceFrame};
-use num_traits::{Float, FloatConst};
+use aether_core::real::Real;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CylinderLocal;
 impl ReferenceFrame for CylinderLocal {}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Cylinder<F: Float> {
+pub struct Cylinder<F: Real> {
     pub r: F,
     pub h: F,
 }
-impl<F: Float + FloatConst> Solid<F> for Cylinder<F> {
+impl<F: Real> Solid<F> for Cylinder<F> {
     type Local = CylinderLocal;
     fn volume(&self) -> F {
-        F::PI() * self.r * self.r * self.h
+        F::PI * self.r * self.r * self.h
     }
     fn inertia_principal_cm(&self, m: F) -> Vector<F, 3> {
-        let half = (F::one() + F::one()).recip();
-        let twelve = F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one();
+        let half = F::from_f64(1.0) / (F::ONE + F::ONE);
+        let twelve = F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE;
         let r2 = self.r * self.r;
         let h2 = self.h * self.h;
         let iz = m * r2 * half;
-        let ixy = m * (F::one() + F::one() + F::one()) * r2 + m * h2; // simplify with constants you prefer
+        let ixy = m * (F::ONE + F::ONE + F::ONE) * r2 + m * h2; // simplify with constants you prefer
         Vector::new([ixy / twelve, ixy / twelve, iz])
     }
 }

--- a/crates/aether_shapes/src/prism.rs
+++ b/crates/aether_shapes/src/prism.rs
@@ -1,6 +1,6 @@
 use crate::attributes::Solid;
 use aether_core::{math::Vector, reference_frame::ReferenceFrame};
-use num_traits::Float;
+use aether_core::real::Real;
 
 // Prism
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -8,32 +8,32 @@ pub struct PrismLocal;
 impl ReferenceFrame for PrismLocal {}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct RectangularPrism<F: Float> {
+pub struct RectangularPrism<F: Real> {
     pub a: F,
     pub b: F,
     pub c: F,
 }
-impl<F: Float> Solid<F> for RectangularPrism<F> {
+impl<F: Real> Solid<F> for RectangularPrism<F> {
     type Local = PrismLocal;
     fn volume(&self) -> F {
         self.a * self.b * self.c
     }
     fn inertia_principal_cm(&self, m: F) -> Vector<F, 3> {
         let (a, b, c) = (self.a, self.b, self.c);
-        let t12 = F::one() + F::one() + F::one() + F::one() + F::one() + F::one(); // 6? ignore; use constants you already have if any
+        let t12 = F::ONE + F::ONE + F::ONE + F::ONE + F::ONE + F::ONE; // 6? ignore; use constants you already have if any
         // Use your existing FromPrimitive helpers; shown directly:
-        let twelve = F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one()
-            + F::one();
+        let twelve = F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE
+            + F::ONE;
         Vector::new([
             m * (b * b + c * c) / twelve,
             m * (a * a + c * c) / twelve,

--- a/crates/aether_shapes/src/sphere.rs
+++ b/crates/aether_shapes/src/sphere.rs
@@ -1,6 +1,6 @@
 use crate::attributes::Solid;
 use aether_core::{math::Vector, reference_frame::ReferenceFrame};
-use num_traits::{Float, FloatConst};
+use aether_core::real::{Real};
 
 // Sphere
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -8,21 +8,21 @@ pub struct SphereLocal;
 impl ReferenceFrame for SphereLocal {}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Sphere<F: Float> {
+pub struct Sphere<F: Real> {
     pub r: F,
 }
-impl<F: Float + FloatConst> Solid<F> for Sphere<F> {
+impl<F: Real> Solid<F> for Sphere<F> {
     type Local = SphereLocal;
     fn volume(&self) -> F {
-        (F::one() + F::one() + F::one() + F::one()) / (F::one() + F::one() + F::one())
-            * F::PI()
+        (F::ONE + F::ONE + F::ONE + F::ONE) / (F::ONE + F::ONE + F::ONE)
+            * F::PI
             * self.r
             * self.r
             * self.r
     }
     fn inertia_principal_cm(&self, m: F) -> Vector<F, 3> {
         let two_fifths =
-            (F::one() + F::one()) / (F::one() + F::one() + F::one() + F::one() + F::one());
+            (F::ONE + F::ONE) / (F::ONE + F::ONE + F::ONE + F::ONE + F::ONE);
         let i = two_fifths * m * self.r * self.r;
         Vector::new([i, i, i])
     }

--- a/crates/aether_stats/src/distributions/bernoulli.rs
+++ b/crates/aether_stats/src/distributions/bernoulli.rs
@@ -1,33 +1,35 @@
-#![cfg(feature = "std")]
-
-use num_traits::{Float, cast::cast };
+use aether_core::real::Real;
 
 /// Bernoulli distribution: P(X=1)=p, P(X=0)=1-p
 #[derive(Clone, Debug)]
-pub struct Bernoulli<F: Float + > {
+pub struct Bernoulli<F: Real> {
     pub p: F,
 }
 
 impl<F> Bernoulli<F>
 where
-    F: Float + ,
+    F: Real,
 {
-    pub fn new(p: F) -> Self { Self { p } }
+    pub fn new(p: F) -> Self {
+        Self { p }
+    }
 
     pub fn pmf(&self, x: u8) -> F {
         match x {
-            0 => F::one() - self.p,
+            0 => F::ONE - self.p,
             1 => self.p,
-            _ => F::zero(),
+            _ => F::ZERO,
         }
     }
 
     /// MLE fit for bernoulli is just sample mean (assumes x in {0,1})
     pub fn fit_mle(samples: &[u8]) -> Self {
-    let mut sum = 0usize;
-    for &s in samples { sum += s as usize; }
-    let total = samples.len().max(1);
-    let p: F = cast::<u32, F>(sum as u32).unwrap() / cast::<u32, F>(total as u32).unwrap();
+        let mut sum = 0usize;
+        for &s in samples {
+            sum += s as usize;
+        }
+        let total = samples.len().max(1);
+        let p = F::from_usize(sum) / F::from_usize(total);
         Self::new(p)
     }
 }

--- a/crates/aether_stats/src/distributions/categorical.rs
+++ b/crates/aether_stats/src/distributions/categorical.rs
@@ -1,28 +1,31 @@
 #![cfg(feature = "std")]
 
-use num_traits::{Float, cast::cast };
+use aether_core::real::Real;
 
 /// Categorical distribution over K categories.
 #[derive(Clone, Debug)]
-pub struct Categorical<F: Float + > {
+pub struct Categorical<F: Real + > {
     pub probs: Vec<F>,
 }
 
 impl<F> Categorical<F>
 where
-    F: Float + ,
+    F: Real + ,
 {
     pub fn new(probs: Vec<F>) -> Self { Self { probs } }
 
     pub fn pmf(&self, k: usize) -> F {
-        if k < self.probs.len() { self.probs[k] } else { F::zero() }
+        if k < self.probs.len() { self.probs[k] } else { F::ZERO }
     }
 
     /// MLE fit: counts normalized
     pub fn fit_mle(counts: &[usize]) -> Self {
-    let total: usize = counts.iter().sum();
-    let total = total.max(1);
-    let probs = counts.iter().map(|&c| cast::<u32, F>(c as u32).unwrap() / cast::<u32, F>(total as u32).unwrap()).collect();
+        let total: usize = counts.iter().sum();
+        let total_f = F::from_usize(total.max(1));
+        let probs: Vec<F> = counts
+            .iter()
+            .map(|&c| F::from_usize(c) / total_f)
+            .collect();
         Self::new(probs)
     }
 }

--- a/crates/aether_stats/src/distributions/gaussian.rs
+++ b/crates/aether_stats/src/distributions/gaussian.rs
@@ -1,18 +1,18 @@
 #![cfg(feature = "std")]
 use aether_core::math::Vector;
 use aether_rand::randomizers::XorShift64Star;
-use num_traits::{Float, FloatConst, cast};
+use aether_core::real::Real;
 
-/// Univariate Gaussian distribution helpers parameterized over a floating type F.
+/// Univariate Gaussian distribution helpers parameterized over a Realing type F.
 #[derive(Clone, Copy, Debug)]
-pub struct Gaussian<F: Float> {
+pub struct Gaussian<F: Real> {
     pub mu: F,
     pub sigma: F,
 }
 
 impl<F> Gaussian<F>
 where
-    F: Float + FloatConst,
+    F: Real,
 {
     /// Create a new Gaussian with mean `mu` and standard deviation `sigma`.
     pub fn new(mu: F, sigma: F) -> Self { Self { mu, sigma } }
@@ -28,33 +28,34 @@ where
         let r = (-2.0_f64 * u1.ln()).sqrt();
         let theta: f64 = 2.0_f64 * core::f64::consts::PI * u2;
         let z0 = r * theta.cos();
-        let z: F = num_traits::cast(z0).expect("conversion from f64 to float failed");
-        z * self.sigma + self.mu
+        let z: F = F::from_f64(z0);
+        let result = self.sigma * z + self.mu;
+        return result
     }
 
     /// Probability density function evaluated at x
     pub fn pdf(&self, x: F) -> F {
-        let two = F::one() + F::one();
-        let half = F::one() / two;
-        let tiny = F::zero();
-        let pi = num_traits::FloatConst::PI();
+        let two = F::ONE + F::ONE;
+        let half = F::ONE / two;
+        let tiny = F::ZERO;
+        let pi = F::PI;
         let var = (self.sigma * self.sigma).max(tiny);
-        let coeff = F::one() / ((two * pi * var).sqrt());
+        let coeff = F::ONE / ((two * pi * var).sqrt());
         let diff = x - self.mu;
         coeff * (-(half * diff * diff / var)).exp()
     }
 
     /// Fit MLE for a set of scalar samples (samples are of type F)
     pub fn fit_mle(samples: &[F]) -> Self {
-        let n_f: F = cast(samples.len() as u32).unwrap();
-        if samples.is_empty() { return Self::new(F::zero(), F::one()); }
-        let mut sum = F::zero();
+        let n_f: F = F::from_usize(samples.len());
+        if samples.is_empty() { return Self::new(F::ZERO, F::ONE); }
+        let mut sum = F::ZERO;
         for &s in samples { sum = sum + s; }
         let mu = sum / n_f;
-        let mut s2 = F::zero();
+        let mut s2 = F::ZERO;
         for &s in samples { let d = s - mu; s2 = s2 + d * d; }
         let sigma_squared = s2 / n_f; // MLE uses 1/n
-        let sigma = sigma_squared.sqrt().max(F::epsilon());
+        let sigma = sigma_squared.sqrt().max(F::EPSILON);
         Self { mu, sigma }
     }
 }

--- a/crates/aether_stats/src/distributions/multivariate.rs
+++ b/crates/aether_stats/src/distributions/multivariate.rs
@@ -1,15 +1,15 @@
 #![cfg(feature = "std")]
 use aether_core::math::{Vector, Matrix};
-use num_traits::{Float, cast::cast };
+use aether_core::real::Real;
 
 /// Multivariate Normal distribution with mean vector and covariance matrix.
 #[derive(Clone, Debug)]
-pub struct MultivariateNormal<F: Float + , const N: usize> {
+pub struct MultivariateNormal<F: Real + , const N: usize> {
     pub mean: Vector<F, N>,
     pub cov: Matrix<F, N, N>,
 }
 
-impl<F: Float + , const N: usize> MultivariateNormal<F, N> {
+impl<F: Real + , const N: usize> MultivariateNormal<F, N> {
     pub fn new(mean: Vector<F, N>, cov: Matrix<F, N, N>) -> Self { Self { mean, cov } }
 
     /// Evaluate the density at x using the formula
@@ -23,10 +23,10 @@ impl<F: Float + , const N: usize> MultivariateNormal<F, N> {
             diff.dot(&tmp)
         };
         let det = self.cov.determinant();
-        let two = F::one() + F::one();
-        let pi = cast(std::f64::consts::PI).unwrap();
-        let denom = ( (two * pi).powf(cast(N as u32).unwrap()) * det ).sqrt();
-        ( (-F::from(0.5).unwrap()) * quad ).exp() / denom
+        let two = F::ONE + F::ONE;
+        let pi = F::PI;
+        let denom = ( (two * pi).powf(F::from_usize(N)) * det ).sqrt();
+        ( (-F::from_f32(0.5)) * quad ).exp() / denom
     }
 }
 

--- a/crates/aether_test/Cargo.toml
+++ b/crates/aether_test/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "*"
 
 # Numerical and comparison helpers
 num-traits = "0.2"
-approx = "0.5" # For float comparison (assert_abs_diff_eq, etc.)
+approx = "0.5" # For Real comparison (assert_abs_diff_eq, etc.)
 
 [dev-dependencies]
 

--- a/crates/aether_units/Cargo.toml
+++ b/crates/aether_units/Cargo.toml
@@ -7,7 +7,6 @@ version.workspace = true
 
 [dependencies]
 aether_core = {path="../aether_core"}
-fpx = {git = "https://github.com/AtmoPierce/fpx.git", features = ["design"]}
 
 [lints]
 workspace = true

--- a/crates/aether_units/src/base/units.rs
+++ b/crates/aether_units/src/base/units.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 use core::ops::{Add, Sub, Mul, Div, Neg};
-use fpx::design::Real;
+use aether_core::real::Real;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Quantity<Unit, T: Real> {

--- a/crates/aether_units/src/si/si.rs
+++ b/crates/aether_units/src/si/si.rs
@@ -1,4 +1,4 @@
-use fpx::Real;
+use aether_core::real::Real;
 use crate::Quantity;
 use crate::si::si_base::*;
 use crate::si::si_composites::*;

--- a/crates/aether_units/src/si/si_prefix.rs
+++ b/crates/aether_units/src/si/si_prefix.rs
@@ -1,5 +1,5 @@
 // ----------------- SI prefixes & prefixed units -----------------
-use fpx::Real;
+use aether_core::real::Real;
 use crate::si::si_base::*;
 
 // SI prefix factors as f32

--- a/crates/aether_units/src/tests/mod.rs
+++ b/crates/aether_units/src/tests/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use fpx::approx;
+    use aether_core::real::Real;
 
     use crate::Quantity;
     use crate::si::si_base::*;


### PR DESCRIPTION
- Replaced all shallow `as` casts with Real::{from_f32, from_f64, from_usize, ...}
- Updated Vector, Matrix, Bernoulli, Categorical, and GD to use Real consistently
- Better assurance sfor type safety across f16/f32/f64/f128 builds
- Removes dependency on num_traits::cast(), and a bunch of unwraps
- Improves numerical determinism and feature-gated float support