### PR TITLE
Vector data serialiation fix

### DIFF
--- a/crates/aether_core/src/math/vector.rs
+++ b/crates/aether_core/src/math/vector.rs
@@ -452,7 +452,7 @@ use core::{fmt, marker::PhantomData};
 #[cfg(feature = "serde")]
 use serde::{
     de::{self, SeqAccess, Visitor},
-    ser::SerializeSeq,
+    ser::{SerializeSeq,SerializeTuple},
     Deserialize, Deserializer, Serialize, Serializer,
 };
 


### PR DESCRIPTION
Fixes error where data is serialized in a method incompatible with the deserialize method for vectors, leading to corrupted values (e.g. unit vector when serialized, large magnitude vector when read / decoded)