### PR TITLE
Bincode support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ name = "aether_core"
 version = "0.1.1"
 dependencies = [
  "approx",
+ "bincode",
  "num-traits",
  "regex",
  "rustyline",
@@ -122,6 +123,7 @@ dependencies = [
  "aether_core",
  "aether_viz",
  "approx",
+ "bincode",
  "num-traits",
  "thiserror",
 ]
@@ -176,6 +178,26 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
 
 [[package]]
 name = "bitflags"
@@ -1088,10 +1110,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/crates/aether_core/Cargo.toml
+++ b/crates/aether_core/Cargo.toml
@@ -7,6 +7,7 @@ license-file.workspace = true
 
 [features]
 default = ["no_std"]
+bincode = ["dep:bincode"]
 std = []
 no_std = []
 f16 = []
@@ -40,6 +41,7 @@ num-traits = "0.2"
 rustyline = { version = "13", optional=true}
 regex = { version = "1", optional=true}
 serde = { version = "1.0", default-features=false, features = ["derive"], optional=true}
+bincode = { version = "2.0.1", optional=true }
 serde-json-core = {version = "0.6.0", optional=true}
 
 [dev-dependencies]

--- a/crates/aether_core/src/attitude/quaternion.rs
+++ b/crates/aether_core/src/attitude/quaternion.rs
@@ -8,6 +8,7 @@ use core::marker::PhantomData;
 use core::ops::{Add, Div, Mul, Neg, Sub};
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 pub struct Quaternion<T: Real, From: ReferenceFrame, To: ReferenceFrame> {
     pub data: Vector<T, 4>, // [w, i, j, k]
     _from: PhantomData<From>,
@@ -364,6 +365,9 @@ where
         )
     }
 }
+
+
+
 
 #[cfg(test)]
 #[path = "tests/quaternion_tests.rs"]

--- a/crates/aether_core/src/coordinate/cartesian.rs
+++ b/crates/aether_core/src/coordinate/cartesian.rs
@@ -9,6 +9,7 @@ use core::slice::{Iter, IterMut};
 use crate::real::Real;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 pub struct Cartesian<T: Real, ReferenceFrame> {
     pub data: Vector<T, 3>,
     pub _reference_frame: PhantomData<ReferenceFrame>,

--- a/crates/aether_core/src/math/vector.rs
+++ b/crates/aether_core/src/math/vector.rs
@@ -10,6 +10,7 @@ use core::ops::{
 use core::slice::{Iter, IterMut};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 pub struct Vector<T, const N: usize> {
     pub data: [T; N],
 }

--- a/crates/aether_core/src/reference_frame/body.rs
+++ b/crates/aether_core/src/reference_frame/body.rs
@@ -5,6 +5,8 @@
 use crate::coordinate::Cartesian;
 use crate::reference_frame::{FixedFrame, ReferenceFrame};
 use crate::real::Real;
+
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Body<T: Real> {
     /// Vector from origin to center of mass in body coordinates

--- a/crates/aether_core/src/reference_frame/icrf.rs
+++ b/crates/aether_core/src/reference_frame/icrf.rs
@@ -2,6 +2,7 @@ use crate::coordinate::Cartesian;
 use crate::reference_frame::ReferenceFrame;
 use crate::real::Real;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ICRF<T: Real> {
     pub epoch: T,

--- a/crates/aether_test/Cargo.toml
+++ b/crates/aether_test/Cargo.toml
@@ -12,10 +12,13 @@ keywords = ["aether", "matrix", "vector", "test", "plot"]
 
 [features]
 plots = ["dep:aether_viz", "aether_viz/svg"]     # or "aether_viz/bitmap"
+bincode = ["dep:bincode"]
 
 [dependencies]
-aether_core = { path = "../aether_core", version = "0.1.1" }
+# aether_core = { path = "../aether_core", version = "0.1.1" }
+aether_core = { path = "../aether_core", features = ["bincode"]}
 aether_viz = { path = "../aether_viz", optional = true, default-features = false }
+bincode = { version = "2.0.1", optional=true }
 thiserror = "*"
 
 # Numerical and comparison helpers

--- a/crates/aether_test/src/assert/coding.rs
+++ b/crates/aether_test/src/assert/coding.rs
@@ -1,0 +1,39 @@
+use aether_core::math::Vector;
+use aether_core::attitude::Quaternion;
+
+#[cfg(feature = "bincode")]
+use bincode::{
+    config::standard,
+    decode_from_slice, encode_into_slice,
+    error::{DecodeError, EncodeError},
+};
+#[cfg(feature = "bincode")]
+pub fn assert_vector_equivalence<const N: usize>(v: &Vector<f64, N>) {
+    let mut buf = [0u8; 1024];    
+
+    let len = bincode::encode_into_slice(v, &mut buf, standard())
+            .expect("Buffer too small!");
+
+    let (decoded, _): (Vector<f64, N>, usize) = bincode::decode_from_slice(&buf[..len], standard())
+    .expect("Decode failed");
+
+    assert_eq!(v, &decoded);
+}
+
+#[cfg(feature = "bincode")]
+pub fn assert_quaternion_equivalence<From, To>(q: &Quaternion<f64, From, To>) 
+where 
+    From: aether_core::reference_frame::ReferenceFrame + std::fmt::Debug + PartialEq + bincode::Encode + bincode::Decode<()>,
+    To: aether_core::reference_frame::ReferenceFrame + std::fmt::Debug + PartialEq + bincode::Encode + bincode::Decode<()>,
+{
+    let mut buf = [0u8; 1024];
+
+    let len = bincode::encode_into_slice(q, &mut buf, standard())
+        .expect("Failed to encode Quaternion");
+
+    let (decoded, _): (Quaternion<f64, From, To>, usize) = 
+        bincode::decode_from_slice(&buf[..len], standard())
+        .expect("Failed to decode Quaternion");
+
+    assert_eq!(q, &decoded);
+}

--- a/crates/aether_test/src/assert/mod.rs
+++ b/crates/aether_test/src/assert/mod.rs
@@ -1,6 +1,7 @@
 pub mod vector;
 pub mod matrix;
 pub mod function;
+pub mod coding;
 
 #[cfg(test)]
 #[path = "tests/mod.rs"]

--- a/crates/aether_test/src/assert/tests/coding.rs
+++ b/crates/aether_test/src/assert/tests/coding.rs
@@ -1,0 +1,23 @@
+use crate::assert::coding::*;
+
+#[cfg(feature = "bincode")]
+#[test]
+fn test_vector_equivalence() {
+    use aether_core::math::Vector;
+
+    let v = Vector::from([1.0, 2.0, 3.0]);
+    assert_vector_equivalence(&v);
+}
+
+#[cfg(feature = "bincode")]
+#[test]
+fn test_quaternion_equivalence() {
+    use aether_core::attitude::Quaternion;
+    use aether_core::reference_frame::{ICRF,Body};
+
+    let q: Quaternion<f64, ICRF<f64>,Body<f64>> = Quaternion::new(0.707, 0.707, 0.0, 0.0);
+    assert_quaternion_equivalence(&q);
+
+    let q: Quaternion<f64, ICRF<f64>,Body<f64>> = Quaternion::identity();
+    assert_quaternion_equivalence(&q);
+}

--- a/crates/aether_test/src/assert/tests/mod.rs
+++ b/crates/aether_test/src/assert/tests/mod.rs
@@ -1,5 +1,6 @@
 pub mod vector;
 pub mod matrix;
+pub mod coding;
 
 #[cfg(feature = "plots")]
 pub mod plots;


### PR DESCRIPTION
Cfg option for bincode on Quaternions, Vectors, and Cartesian.

Test with 

cargo test -p aether_test --features bincode test_vector_equivalence

cargo test -p aether_test --features bincode test_quaternion_equivalence